### PR TITLE
Add custom exchange queries + initial portfolio detector

### DIFF
--- a/lib/all-trans.js
+++ b/lib/all-trans.js
@@ -9,13 +9,13 @@ return Promise.all([
 	gdax.getAllTransactions(),
 	coinbase.getAllTransactions()
 ])
-.then(trans => {
-	const gdaxTrans = trans[0];
-	const cbTrans = trans[1];
+.then(trx => {
+	const gdaxTrans = trx[0];
+	const cbTrans = trx[1];
 	Object.keys(gdaxTrans).forEach(currency => {
 		tranCounts[currency] = {
-			gdax: gdaxTrans[currency].trans.length,
-			cb: cbTrans[currency].trans.length
+			gdax: gdaxTrans[currency].trx.length,
+			cb: cbTrans[currency].trx.length
 		};
 	});
 	console.log(tranCounts);

--- a/lib/all-trans.js
+++ b/lib/all-trans.js
@@ -4,6 +4,7 @@ const gdax = require('./exchanges/gdax');
 const coinbase = require('./exchanges/coinbase');
 const bitfinex = require('./exchanges/bitfinex');
 const bittrex = require('./exchanges/bittrex');
+const poloniex = require('./exchanges/poloniex');
 
 const cryptodb = require('./mongo-db');
 
@@ -11,7 +12,7 @@ const tranCounts = {};
 
 return Promise.all([
 	cryptodb.connect(),
-	gdax.getAllTransactions().catch(err => {
+	/*gdax.getAllTransactions().catch(err => {
 		console.error('gdax failed');
 		console.error(err);
 		return {};
@@ -30,6 +31,12 @@ return Promise.all([
 		console.error('bittrex failed');
 		console.error(err);
 		return {};
+	}),*/
+	{}, {}, {}, {},
+	poloniex.getAllTransactions().catch(err => {
+		console.error('poloniex failed');
+		console.error(err);
+		return {};
 	})
 ])
 .then(trx => {
@@ -38,18 +45,21 @@ return Promise.all([
 	const cbTrans = trx[2];
 	const bfxTrans = trx[3];
 	const bxTrans = trx[4];
+	const poloTrans = trx[5];
 
 	const collgdax = db.collection('gdax');
 	const collcoinbase = db.collection('coinbase');
 	const collbitfinex = db.collection('bitfinex');
 	const collbittrex = db.collection('bittrex');
+	const collpoloniex = db.collection('poloniex');
 
 	Object.keys(gdaxTrans).forEach(currency => {
 		tranCounts[currency] = {
 			gdax: gdaxTrans[currency].trx.length,
 			cb: cbTrans[currency].trx.length,
 			bfx: 0,
-			bx: 0
+			bx: 0,
+			polo: 0
 		};
 	});
 	Object.keys(bfxTrans).forEach(currency => {
@@ -57,7 +67,8 @@ return Promise.all([
 			tranCounts[currency] = {
 				gdax: 0,
 				cb: 0,
-				bx: 0
+				bx: 0,
+				polo: 0
 			};
 		}
 		tranCounts[currency].bfx = bfxTrans[currency].trx.length;
@@ -67,10 +78,22 @@ return Promise.all([
 			tranCounts[currency] = {
 				gdax: 0,
 				cb: 0,
-				bfx: 0
+				bfx: 0,
+				polo: 0
 			};
 		}
 		tranCounts[currency].bx = bxTrans[currency].trx.length;
+	});
+	Object.keys(poloTrans).forEach(currency => {
+		if (!tranCounts[currency]) {
+			tranCounts[currency] = {
+				gdax: 0,
+				cb: 0,
+				bfx: 0,
+				bx: 0
+			};
+		}
+		tranCounts[currency].polo = poloTrans[currency].trx.length;
 	});
 
 	return Promise.each(Object.keys(tranCounts), currency => {
@@ -95,6 +118,12 @@ return Promise.all([
 		}
 		if (bxTrans[currency] && bxTrans[currency].trx.length) {
 			toResolve.push(collbittrex.insertAsync(bxTrans[currency].trx)
+				.then(res => {
+					return res.result;
+				}));
+		}
+		if (poloTrans[currency] && poloTrans[currency].trx.length) {
+			toResolve.push(collpoloniex.insertAsync(poloTrans[currency].trx)
 				.then(res => {
 					return res.result;
 				}));

--- a/lib/all-trans.js
+++ b/lib/all-trans.js
@@ -3,21 +3,45 @@ const Promise = require('bluebird');
 const gdax = require('./exchanges/gdax');
 const coinbase = require('./exchanges/coinbase');
 
+const cryptodb = require('./mongo-db');
+
 const tranCounts = {};
 
 return Promise.all([
 	gdax.getAllTransactions(),
-	coinbase.getAllTransactions()
+	coinbase.getAllTransactions(),
+	cryptodb.connect()
 ])
 .then(trx => {
 	const gdaxTrans = trx[0];
 	const cbTrans = trx[1];
+	const db = trx[2];
+	const collgdax = db.collection('gdax');
+	const collcoinbase = db.collection('coinbase');
 	Object.keys(gdaxTrans).forEach(currency => {
 		tranCounts[currency] = {
 			gdax: gdaxTrans[currency].trx.length,
 			cb: cbTrans[currency].trx.length
 		};
 	});
-	console.log(tranCounts);
+
+	/*
+	return Promise.each(Object.keys(gdaxTrans), currency => {
+		return Promise.all([
+			collgdax.insertAsync(gdaxTrans[currency].trx),
+			collcoinbase.insertAsync(cbTrans[currency].trx)
+		])
+		.then(res => {
+			console.log(`Results for ${currency}:`);
+			console.log(res);
+		})
+		.then(() => {
+			return tranCounts;
+		})
+	});*/
+	return tranCounts;
+})
+.then(counts => {
+	console.log(counts);
 	process.exit();
-});
+})

--- a/lib/all-trans.js
+++ b/lib/all-trans.js
@@ -13,7 +13,7 @@ const tranCounts = {};
 
 return Promise.all([
 	cryptodb.connect(),
-	/*gdax.getAllTransactions().catch(err => {
+	gdax.getAllTransactions().catch(err => {
 		console.error('gdax failed');
 		console.error(err);
 		return {};
@@ -37,8 +37,7 @@ return Promise.all([
 		console.error('poloniex failed');
 		console.error(err);
 		return {};
-	})*/
-	{}, {}, {}, {}, {},
+	}),
 	cryptopia.getAllTransactions().catch(err => {
 		console.error('cryptopia failed');
 		console.error(err);
@@ -64,12 +63,24 @@ return Promise.all([
 	Object.keys(gdaxTrans).forEach(currency => {
 		tranCounts[currency] = {
 			gdax: gdaxTrans[currency].trx.length,
-			cb: cbTrans[currency].trx.length,
+			cb: 0,
 			bfx: 0,
 			bx: 0,
 			polo: 0,
 			crypt: 0,
 		};
+	});
+	Object.keys(cbTrans).forEach(currency => {
+		if (!tranCounts[currency]) {
+			tranCounts[currency] = {
+				gdax: 0,
+				bfx: 0,
+				bx: 0,
+				polo: 0,
+				crypt: 0
+			};
+		}
+		tranCounts[currency].cb = cbTrans[currency].trx.length;
 	});
 	Object.keys(bfxTrans).forEach(currency => {
 		if (!tranCounts[currency]) {

--- a/lib/all-trans.js
+++ b/lib/all-trans.js
@@ -1,11 +1,23 @@
-const gdax = require('./exchanges/gdax');
+const Promise = require('bluebird');
 
-return gdax.getAllTransactions()
-	.then(gdaxTrans => {
-		console.log(JSON.stringify(gdaxTrans));
-		process.exit();
-	})
-	.catch(err => {
-		console.error(err);
-		process.exit();
+const gdax = require('./exchanges/gdax');
+const coinbase = require('./exchanges/coinbase');
+
+const tranCounts = {};
+
+return Promise.all([
+	gdax.getAllTransactions(),
+	coinbase.getAllTransactions()
+])
+.then(trans => {
+	const gdaxTrans = trans[0];
+	const cbTrans = trans[1];
+	Object.keys(gdaxTrans).forEach(currency => {
+		tranCounts[currency] = {
+			gdax: gdaxTrans[currency].trans.length,
+			cb: cbTrans[currency].trans.length
+		};
 	});
+	console.log(tranCounts);
+	process.exit();
+});

--- a/lib/all-trans.js
+++ b/lib/all-trans.js
@@ -6,6 +6,7 @@ const bitfinex = require('./exchanges/bitfinex');
 const bittrex = require('./exchanges/bittrex');
 const poloniex = require('./exchanges/poloniex');
 const cryptopia = require('./exchanges/cryptopia');
+const bitstamp = require('./exchanges/bitstamp');
 
 const cryptodb = require('./mongo-db');
 
@@ -42,6 +43,11 @@ return Promise.all([
 		console.error('cryptopia failed');
 		console.error(err);
 		return {};
+	}),
+	bitstamp.getAllTransactions().catch(err => {
+		console.error('bitstamp failed');
+		console.error(err);
+		return {};
 	})
 ])
 .then(trx => {
@@ -52,6 +58,7 @@ return Promise.all([
 	const bxTrans = trx[4];
 	const poloTrans = trx[5];
 	const crypTrans = trx[6];
+	const bsTrans = trx[7];
 
 	const collgdax = db.collection('gdax');
 	const collcoinbase = db.collection('coinbase');
@@ -59,6 +66,7 @@ return Promise.all([
 	const collbittrex = db.collection('bittrex');
 	const collpoloniex = db.collection('poloniex');
 	const collcryptopia = db.collection('cryptopia');
+	const collbitstamp = db.collection('bitstamp');
 
 	Object.keys(gdaxTrans).forEach(currency => {
 		tranCounts[currency] = {
@@ -68,6 +76,7 @@ return Promise.all([
 			bx: 0,
 			polo: 0,
 			crypt: 0,
+			bs: 0
 		};
 	});
 	Object.keys(cbTrans).forEach(currency => {
@@ -77,7 +86,8 @@ return Promise.all([
 				bfx: 0,
 				bx: 0,
 				polo: 0,
-				crypt: 0
+				crypt: 0,
+				bs: 0
 			};
 		}
 		tranCounts[currency].cb = cbTrans[currency].trx.length;
@@ -89,7 +99,8 @@ return Promise.all([
 				cb: 0,
 				bx: 0,
 				polo: 0,
-				crypt: 0
+				crypt: 0,
+				bs: 0
 			};
 		}
 		tranCounts[currency].bfx = bfxTrans[currency].trx.length;
@@ -101,7 +112,8 @@ return Promise.all([
 				cb: 0,
 				bfx: 0,
 				polo: 0,
-				crypt: 0
+				crypt: 0,
+				bs: 0
 			};
 		}
 		tranCounts[currency].bx = bxTrans[currency].trx.length;
@@ -113,7 +125,8 @@ return Promise.all([
 				cb: 0,
 				bfx: 0,
 				bx: 0,
-				crypt: 0
+				crypt: 0,
+				bs: 0
 			};
 		}
 		tranCounts[currency].polo = poloTrans[currency].trx.length;
@@ -124,10 +137,25 @@ return Promise.all([
 				gdax: 0,
 				cb: 0,
 				bfx: 0,
-				bx: 0
+				polo: 0,
+				bx: 0,
+				bs: 0
 			};
 		}
 		tranCounts[currency].crypt = crypTrans[currency].trx.length;
+	});
+	Object.keys(bsTrans).forEach(currency => {
+		if (!tranCounts[currency]) {
+			tranCounts[currency] = {
+				gdax: 0,
+				cb: 0,
+				bfx: 0,
+				polo: 0,
+				bx: 0,
+				crypt: 0
+			};
+		}
+		tranCounts[currency].bs = bsTrans[currency].trx.length;
 	});
 
 	return Promise.each(Object.keys(tranCounts), currency => {
@@ -164,6 +192,12 @@ return Promise.all([
 		}
 		if (crypTrans[currency] && crypTrans[currency].trx.length) {
 			toResolve.push(collcryptopia.insertAsync(crypTrans[currency].trx)
+				.then(res => {
+					return res.result;
+				}));
+		}
+		if (bsTrans[currency] && bsTrans[currency].trx.length) {
+			toResolve.push(collbitstamp.insertAsync(bsTrans[currency].trx)
 				.then(res => {
 					return res.result;
 				}));

--- a/lib/all-trans.js
+++ b/lib/all-trans.js
@@ -3,30 +3,53 @@ const Promise = require('bluebird');
 const gdax = require('./exchanges/gdax');
 const coinbase = require('./exchanges/coinbase');
 const bitfinex = require('./exchanges/bitfinex');
+const bittrex = require('./exchanges/bittrex');
 
 const cryptodb = require('./mongo-db');
 
 const tranCounts = {};
 
 return Promise.all([
-	gdax.getAllTransactions(),
-	coinbase.getAllTransactions(),
-	bitfinex.getAllTransactions(),
-	cryptodb.connect()
+	cryptodb.connect(),
+	gdax.getAllTransactions().catch(err => {
+		console.error('gdax failed');
+		console.error(err);
+		return {};
+	}),
+	coinbase.getAllTransactions().catch(err => {
+		console.error('coinbase failed');
+		console.error(err);
+		return {};
+	}),
+	bitfinex.getAllTransactions().catch(err => {
+		console.error('bitfinex failed');
+		console.error(err);
+		return {};
+	}),
+	bittrex.getAllTransactions().catch(err => {
+		console.error('bittrex failed');
+		console.error(err);
+		return {};
+	})
 ])
 .then(trx => {
-	const gdaxTrans = trx[0];
-	const cbTrans = trx[1];
-	const bfxTrans = trx[2];
-	const db = trx[3];
+	const db = trx[0];
+	const gdaxTrans = trx[1];
+	const cbTrans = trx[2];
+	const bfxTrans = trx[3];
+	const bxTrans = trx[4];
+
 	const collgdax = db.collection('gdax');
 	const collcoinbase = db.collection('coinbase');
 	const collbitfinex = db.collection('bitfinex');
+	const collbittrex = db.collection('bittrex');
+
 	Object.keys(gdaxTrans).forEach(currency => {
 		tranCounts[currency] = {
 			gdax: gdaxTrans[currency].trx.length,
 			cb: cbTrans[currency].trx.length,
-			bfx: 0
+			bfx: 0,
+			bx: 0
 		};
 	});
 	Object.keys(bfxTrans).forEach(currency => {
@@ -34,10 +57,20 @@ return Promise.all([
 			tranCounts[currency] = {
 				gdax: 0,
 				cb: 0,
-				bfx: 0
+				bx: 0
 			};
 		}
 		tranCounts[currency].bfx = bfxTrans[currency].trx.length;
+	});
+	Object.keys(bxTrans).forEach(currency => {
+		if (!tranCounts[currency]) {
+			tranCounts[currency] = {
+				gdax: 0,
+				cb: 0,
+				bfx: 0
+			};
+		}
+		tranCounts[currency].bx = bxTrans[currency].trx.length;
 	});
 
 	return Promise.each(Object.keys(tranCounts), currency => {
@@ -60,6 +93,12 @@ return Promise.all([
 					return res.result;
 				}));
 		}
+		if (bxTrans[currency] && bxTrans[currency].trx.length) {
+			toResolve.push(collbittrex.insertAsync(bxTrans[currency].trx)
+				.then(res => {
+					return res.result;
+				}));
+		}
 		return Promise.all(toResolve)
 			.then(res => {
 				console.log(`Results for ${currency}:`);
@@ -76,3 +115,7 @@ return Promise.all([
 	console.log(counts);
 	process.exit();
 })
+.catch(err => {
+	console.error(err);
+	process.exit();
+});

--- a/lib/all-trans.js
+++ b/lib/all-trans.js
@@ -1,0 +1,11 @@
+const gdax = require('./exchanges/gdax');
+
+return gdax.getAllTransactions()
+	.then(gdaxTrans => {
+		console.log(JSON.stringify(gdaxTrans));
+		process.exit();
+	})
+	.catch(err => {
+		console.error(err);
+		process.exit();
+	});

--- a/lib/all-trans.js
+++ b/lib/all-trans.js
@@ -5,6 +5,7 @@ const coinbase = require('./exchanges/coinbase');
 const bitfinex = require('./exchanges/bitfinex');
 const bittrex = require('./exchanges/bittrex');
 const poloniex = require('./exchanges/poloniex');
+const cryptopia = require('./exchanges/cryptopia');
 
 const cryptodb = require('./mongo-db');
 
@@ -31,10 +32,15 @@ return Promise.all([
 		console.error('bittrex failed');
 		console.error(err);
 		return {};
-	}),*/
-	{}, {}, {}, {},
+	}),
 	poloniex.getAllTransactions().catch(err => {
 		console.error('poloniex failed');
+		console.error(err);
+		return {};
+	})*/
+	{}, {}, {}, {}, {},
+	cryptopia.getAllTransactions().catch(err => {
+		console.error('cryptopia failed');
 		console.error(err);
 		return {};
 	})
@@ -46,12 +52,14 @@ return Promise.all([
 	const bfxTrans = trx[3];
 	const bxTrans = trx[4];
 	const poloTrans = trx[5];
+	const crypTrans = trx[6];
 
 	const collgdax = db.collection('gdax');
 	const collcoinbase = db.collection('coinbase');
 	const collbitfinex = db.collection('bitfinex');
 	const collbittrex = db.collection('bittrex');
 	const collpoloniex = db.collection('poloniex');
+	const collcryptopia = db.collection('cryptopia');
 
 	Object.keys(gdaxTrans).forEach(currency => {
 		tranCounts[currency] = {
@@ -59,7 +67,8 @@ return Promise.all([
 			cb: cbTrans[currency].trx.length,
 			bfx: 0,
 			bx: 0,
-			polo: 0
+			polo: 0,
+			crypt: 0,
 		};
 	});
 	Object.keys(bfxTrans).forEach(currency => {
@@ -68,7 +77,8 @@ return Promise.all([
 				gdax: 0,
 				cb: 0,
 				bx: 0,
-				polo: 0
+				polo: 0,
+				crypt: 0
 			};
 		}
 		tranCounts[currency].bfx = bfxTrans[currency].trx.length;
@@ -79,7 +89,8 @@ return Promise.all([
 				gdax: 0,
 				cb: 0,
 				bfx: 0,
-				polo: 0
+				polo: 0,
+				crypt: 0
 			};
 		}
 		tranCounts[currency].bx = bxTrans[currency].trx.length;
@@ -90,10 +101,22 @@ return Promise.all([
 				gdax: 0,
 				cb: 0,
 				bfx: 0,
-				bx: 0
+				bx: 0,
+				crypt: 0
 			};
 		}
 		tranCounts[currency].polo = poloTrans[currency].trx.length;
+	});
+	Object.keys(crypTrans).forEach(currency => {
+		if (!tranCounts[currency]) {
+			tranCounts[currency] = {
+				gdax: 0,
+				cb: 0,
+				bfx: 0,
+				bx: 0
+			};
+		}
+		tranCounts[currency].crypt = crypTrans[currency].trx.length;
 	});
 
 	return Promise.each(Object.keys(tranCounts), currency => {
@@ -124,6 +147,12 @@ return Promise.all([
 		}
 		if (poloTrans[currency] && poloTrans[currency].trx.length) {
 			toResolve.push(collpoloniex.insertAsync(poloTrans[currency].trx)
+				.then(res => {
+					return res.result;
+				}));
+		}
+		if (crypTrans[currency] && crypTrans[currency].trx.length) {
+			toResolve.push(collcryptopia.insertAsync(crypTrans[currency].trx)
 				.then(res => {
 					return res.result;
 				}));

--- a/lib/all-trans.js
+++ b/lib/all-trans.js
@@ -2,6 +2,7 @@ const Promise = require('bluebird');
 
 const gdax = require('./exchanges/gdax');
 const coinbase = require('./exchanges/coinbase');
+const bitfinex = require('./exchanges/bitfinex');
 
 const cryptodb = require('./mongo-db');
 
@@ -10,36 +11,66 @@ const tranCounts = {};
 return Promise.all([
 	gdax.getAllTransactions(),
 	coinbase.getAllTransactions(),
+	bitfinex.getAllTransactions(),
 	cryptodb.connect()
 ])
 .then(trx => {
 	const gdaxTrans = trx[0];
 	const cbTrans = trx[1];
-	const db = trx[2];
+	const bfxTrans = trx[2];
+	const db = trx[3];
 	const collgdax = db.collection('gdax');
 	const collcoinbase = db.collection('coinbase');
+	const collbitfinex = db.collection('bitfinex');
 	Object.keys(gdaxTrans).forEach(currency => {
 		tranCounts[currency] = {
 			gdax: gdaxTrans[currency].trx.length,
-			cb: cbTrans[currency].trx.length
+			cb: cbTrans[currency].trx.length,
+			bfx: 0
 		};
 	});
+	Object.keys(bfxTrans).forEach(currency => {
+		if (!tranCounts[currency]) {
+			tranCounts[currency] = {
+				gdax: 0,
+				cb: 0,
+				bfx: 0
+			};
+		}
+		tranCounts[currency].bfx = bfxTrans[currency].trx.length;
+	});
 
-	/*
-	return Promise.each(Object.keys(gdaxTrans), currency => {
-		return Promise.all([
-			collgdax.insertAsync(gdaxTrans[currency].trx),
-			collcoinbase.insertAsync(cbTrans[currency].trx)
-		])
-		.then(res => {
-			console.log(`Results for ${currency}:`);
-			console.log(res);
-		})
-		.then(() => {
-			return tranCounts;
-		})
-	});*/
-	return tranCounts;
+	return Promise.each(Object.keys(tranCounts), currency => {
+		const toResolve = [];
+		if (gdaxTrans[currency] && gdaxTrans[currency].trx.length) {
+			toResolve.push(collgdax.insertAsync(gdaxTrans[currency].trx)
+				.then(res => {
+					return res.result;
+				}));
+		}
+		if (cbTrans[currency] && cbTrans[currency].trx.length) {
+			toResolve.push(collcoinbase.insertAsync(cbTrans[currency].trx)
+				.then(res => {
+					return res.result;
+				}));
+		}
+		if (bfxTrans[currency] && bfxTrans[currency].trx.length) {
+			toResolve.push(collbitfinex.insertAsync(bfxTrans[currency].trx)
+				.then(res => {
+					return res.result;
+				}));
+		}
+		return Promise.all(toResolve)
+			.then(res => {
+				console.log(`Results for ${currency}:`);
+				console.log(res);
+			});
+	})
+	.then(() => {
+		return tranCounts;
+	});
+
+	//return tranCounts;
 })
 .then(counts => {
 	console.log(counts);

--- a/lib/exchanges/bitfinex.js
+++ b/lib/exchanges/bitfinex.js
@@ -1,0 +1,142 @@
+const Promise = require('bluebird');
+const moment = require('moment');
+const _ = require('lodash');
+const parseNum = require('parse-decimal-number');
+
+const Bitfinex = require('bitfinex-api-node');
+//const restAPI = bitfinex.APIRest;
+//Promise.promisifyAll(restAPI.prototype);
+
+const keys = require('../../api-key')['bitfinex'];
+
+const bitfinex = new Bitfinex(keys.api_key, keys.api_secret);
+Promise.promisifyAll(bitfinex.rest);
+
+const currencies = {};
+
+//return bitfinex.rest.past_tradesAsync('btcusd')
+//return bitfinex.rest.balance_historyAsync('btc')
+//return bitfinex.rest.movementsAsync('btc')
+return bitfinex.rest.get_symbolsAsync()
+	.then(markets => {
+		pairs.forEach(market => {
+			const targetCurr = market.substr(0, 3).toUpperCase();
+			const sourceCurr = market.substr(3, 3).toUpperCase();
+			if (!currencies[targetCurr]) {
+				currencies[targetCurr] = {
+					exchange: 'bitfinex',
+					currency: targetCurr,
+					trx: []
+				};
+			}
+		});
+	})
+	.then(data => {
+		console.log(data);
+		process.exit();
+	})
+	.catch(err => {
+		console.error(err);
+		process.exit();
+	});
+
+
+/* past_trades
+[  { price: '1252.0',
+    amount: '0.45607028',
+    timestamp: '1492489581.0',
+    type: 'Buy',
+    fee_currency: 'BTC',
+    fee_amount: '-0.00082093',
+    tid: 29405445,
+    order_id: 2334258873 },
+  { price: '1207.5',
+    amount: '0.060532',
+    timestamp: '1492407232.0',
+    type: 'Sell',
+    fee_currency: 'USD',
+    fee_amount: '-0.06578315',
+    tid: 29344790,
+    order_id: 2328246265 }
+]
+*/
+
+/* balance_history
+[
+{ currency: 'BTC',
+    amount: '0.13074219',
+    balance: '0.23645412',
+    description: 'Deposit (BITCOIN) #2168494 on wallet Exchange',
+    timestamp: '1497404114.0' },
+{ currency: 'BTC',
+    amount: '-0.0001',
+    balance: '0.35064598',
+    description: 'Crypto Withdrawal fee on wallet Exchange',
+    timestamp: '1496812280.0' },
+  { currency: 'BTC',
+    amount: '-0.11413851',
+    balance: '0.23650747',
+    description: 'Bitcoin Withdrawal #2111748 on wallet Exchange',
+    timestamp: '1496812280.0' },
+  { currency: 'BTC',
+    amount: '-0.00002044',
+    balance: '0.34052538',
+    description: 'Trading fees for 0.956 LTC (LTCBTC) @ 0.0107 on BFX (0.2%) on wallet Exchange',
+    timestamp: '1496812036.0' },
+  { currency: 'BTC',
+    amount: '0.0102206',
+    balance: '0.35074598',
+    description: 'Exchange 0.956 LTC for BTC @ 0.010691 on wallet Exchange',
+    timestamp: '1496812036.0' }
+]
+*/
+
+/* movements
+{ id: 2168494,
+    currency: 'BTC',
+    method: 'BITCOIN',
+    type: 'DEPOSIT',
+    amount: '0.13074219',
+    description: '6c2303a443e1e795afd66a8dc9659636ff6a1a398ed99fd89e45b15f75421fc3',
+    address: '1HQuKJDgcR9B6Nd6LWj9ASGyfey3PMpnUZ',
+    status: 'COMPLETED',
+    timestamp: '1497404114.0',
+    txid: '6c2303a443e1e795afd66a8dc9659636ff6a1a398ed99fd89e45b15f75421fc3' },
+  { id: 2111748,
+    currency: 'BTC',
+    method: 'BITCOIN',
+    type: 'WITHDRAWAL',
+    amount: '0.11413851',
+    description: '1CsiZp9xvPJmTPfCUnrvAMby1vdPKMPLP8, txid: f011b549c6231e72c0b369e5659288f642576e18548375f4588e342be34df8ce',
+    address: '1CsiZp9xvPJmTPfCUnrvAMby1vdPKMPLP8',
+    status: 'COMPLETED',
+    timestamp: '1496814182.0',
+    txid: 'f011b549c6231e72c0b369e5659288f642576e18548375f4588e342be34df8ce' }
+*/
+
+/* get_symbols
+[ 'btcusd',
+  'ltcusd',
+  'ltcbtc',
+  'ethusd',
+  'ethbtc',
+  'etcbtc',
+  'etcusd',
+  'rrtusd',
+  'rrtbtc',
+  'zecusd',
+  'zecbtc',
+  'xmrusd',
+  'xmrbtc',
+  'dshusd',
+  'dshbtc',
+  'bccbtc',
+  'bcubtc',
+  'bccusd',
+  'bcuusd',
+  'xrpusd',
+  'xrpbtc',
+  'iotusd',
+  'iotbtc' ]
+
+*/

--- a/lib/exchanges/bitfinex.js
+++ b/lib/exchanges/bitfinex.js
@@ -15,7 +15,7 @@ Promise.promisifyAll(bitfinex.rest);
 module.exports = {
 	/* Sample output
 	"LTC": {
-	    "exchange": "gdax",
+	    "exchange": "bitfinex",
 	    "currency": "LTC",
 	    "trx": [
 	    	{ exchange: 'bitfinex',
@@ -58,7 +58,7 @@ module.exports = {
 	    ]
 	},
 	"XRP": {
-		"exchange": "gdax",
+		"exchange": "bitfinex",
 	    "currency": "LTC",
 	    "trx": [
 	    	{ exchange: 'bitfinex',
@@ -197,7 +197,7 @@ module.exports = {
 									description: trade.description
 								};
 								if (parts[0] === 'Deposit' || (parts[1] === 'Withdrawal' && parts[2] !== 'fee')) {
-									trx.type = parts[0] === 'Deposit' ? 'despoit' : 'withdrawal';
+									trx.type = parts[0] === 'Deposit' ? 'deposit' : 'withdrawal';
 									trx.movement_id = parseNum(parts[2].substr(1,7));
 									if (!moves[trx.movement_id]) {
 										console.error(`Missing move ${trx.movement_id} for trx`);
@@ -207,7 +207,7 @@ module.exports = {
 									unusedMoves[trx.movement_id] = false;
 									const moveDt = moment(theMove.timestamp, 'X');
 									const amt = parseNum(theMove.amount);
-									trx.move = {
+									trx.fill = {
 										type: theMove.type.toLowerCase(),
 										currency: currency,
 										amount: amt,

--- a/lib/exchanges/bitfinex.js
+++ b/lib/exchanges/bitfinex.js
@@ -13,26 +13,129 @@ const bitfinex = new Bitfinex(keys.api_key, keys.api_secret);
 Promise.promisifyAll(bitfinex.rest);
 
 const currencies = {};
+const mt = moment().subtract(5, 'months');
+const ts = mt.format('X') + '.0';
 
 //return bitfinex.rest.past_tradesAsync('btcusd')
 //return bitfinex.rest.balance_historyAsync('btc')
 //return bitfinex.rest.movementsAsync('btc')
 return bitfinex.rest.get_symbolsAsync()
 	.then(markets => {
-		pairs.forEach(market => {
+		const currTrades = [];
+		//return Promise.each(markets, market => {
+		return Promise.each(['ltcusd', 'ltcbtc', 'xrpusd', 'xrpbtc'], market => {
 			const targetCurr = market.substr(0, 3).toUpperCase();
 			const sourceCurr = market.substr(3, 3).toUpperCase();
-			if (!currencies[targetCurr]) {
-				currencies[targetCurr] = {
-					exchange: 'bitfinex',
-					currency: targetCurr,
-					trx: []
-				};
-			}
+			return bitfinex.rest.past_tradesAsync(market, { timestamp: ts, limit_trades: 1000 })
+				.then(trades => {
+					currTrades.push({
+						targetCurr: targetCurr,
+						sourceCurr: sourceCurr,
+						trades: trades
+					});
+				});
+		})
+		.then(() => {
+			return currTrades;
 		});
 	})
-	.then(data => {
-		console.log(data);
+	.then(currencyTrades => {
+		currencyTrades.forEach(currData => {
+			const currency = currData.targetCurr;
+			const sourceCurr = currData.sourceCurr;
+			if (!currencies[currency]) {
+				currencies[currency] = {
+					exchange: 'bitfinex',
+					currency: currency,
+					trades: {}
+				};
+			}
+			currencies[currency].trades[sourceCurr] = currData.trades.map(trade => {
+				const dt = moment(trade.timestamp, 'X');
+				const amt = parseNum(trade.amount);
+				const netAmount = trade.type.toLowerCase() === 'buy' ? amt : 0 - amt;
+				return {
+					exchange: 'bitfinex',
+					type: trade.type.toLowerCase(),
+					currency: currency,
+					amount: amt,
+					change: netAmount,
+					price: parseNum(trade.price),
+					price_currency: sourceCurr,
+					date: dt.toDate(),
+					ts: +dt,
+					fee: parseNum(trade.fee_amount),
+					fee_currency: trade.fee_currency,
+					pair: `${currency.toUpperCase()}_${sourceCurr.toUpperCase()}`,
+					tid: trade.tid,
+					order_id: trade.order_id
+				};
+			});
+		});
+		return Promise.each(Object.keys(currencies), currency => {
+			return bitfinex.rest.balance_historyAsync(currency.toLowerCase(), { since: ts, limit: 2000 })
+				.then(history => {
+					currencies[currency].history = history.map(trade => {
+						const dt = moment(trade.timestamp, 'X');
+						const amt = parseNum(trade.amount);
+						const parts = trade.description.split(' ');
+						const trx = {
+							exchange: 'bitfinex',
+							type: '?',
+							currency: trade.currency,
+							amount: Math.abs(amt),
+							change: amt,
+							date: dt.toDate(),
+							ts: +dt,
+							balance: parseNum(trade.balance),
+							description: trade.description
+						};
+						if (parts[0] === 'Deposit') {
+							trx.type = 'despoit';
+							trx.movement_id = parseNum(parts[2].substr(1,7));
+							console.log(`++ deposit ${trx.movement_id} ! (${trade.description})`);
+							console.log('    ' + JSON.stringify(trx));
+						} else if (parts[1] === 'Withdrawal' && parts[2] !== 'fee') {
+							trx.type = 'withdrawal';
+							trx.movement_id = parseNum(parts[2].substr(1,7));
+							console.log(`++ withdrawal ${trx.movement_id} ! (${trade.description})`);
+							console.log('    ' + JSON.stringify(trx));
+						} else if (parts[0] === 'Exchange') {
+							trx.type = (amt > 0) ? 'buy' : 'sell';
+							trx.price_rnd = parseNum(parts[6]);
+							trx.price_currency = parts[4];
+							trx.pair = `${currency}_${trx.price_currency}`;
+							console.log(trade.description);
+							console.log('    ' + JSON.stringify(trx));
+						} else {
+							console.log(trade.description);
+						}
+					});
+					return bitfinex.rest.movementsAsync(currency.toLowerCase(), { since: ts, limit: 2000 });
+				})
+				.then(movements => {
+					currencies[currency].movements = movements;
+					return Promise.resolve(currencies[currency]);
+				});
+		});
+	})
+	.then(() => {
+		const summary = {};
+		Object.keys(currencies).forEach(currency => {
+			const currInfo = currencies[currency];
+			summary[currency] = {
+				trades: [],
+				history: currInfo.history.length,
+				movements: currInfo.movements.length
+			};
+			Object.keys(currInfo.trades).forEach(otherCurr => {
+				summary[currency].trades.push({
+					pair: `${currency}_${otherCurr}`,
+					trades: currInfo.trades[otherCurr].length
+				});
+			});
+		});
+		console.log(JSON.stringify(summary, null, 2));
 		process.exit();
 	})
 	.catch(err => {
@@ -41,102 +144,103 @@ return bitfinex.rest.get_symbolsAsync()
 	});
 
 
+
 /* past_trades
 [  { price: '1252.0',
-    amount: '0.45607028',
-    timestamp: '1492489581.0',
-    type: 'Buy',
-    fee_currency: 'BTC',
-    fee_amount: '-0.00082093',
-    tid: 29405445,
-    order_id: 2334258873 },
-  { price: '1207.5',
-    amount: '0.060532',
-    timestamp: '1492407232.0',
-    type: 'Sell',
-    fee_currency: 'USD',
-    fee_amount: '-0.06578315',
-    tid: 29344790,
-    order_id: 2328246265 }
+		amount: '0.45607028',
+		timestamp: '1492489581.0',
+		type: 'Buy',
+		fee_currency: 'BTC',
+		fee_amount: '-0.00082093',
+		tid: 29405445,
+		order_id: 2334258873 },
+	{ price: '1207.5',
+		amount: '0.060532',
+		timestamp: '1492407232.0',
+		type: 'Sell',
+		fee_currency: 'USD',
+		fee_amount: '-0.06578315',
+		tid: 29344790,
+		order_id: 2328246265 }
 ]
 */
 
 /* balance_history
 [
 { currency: 'BTC',
-    amount: '0.13074219',
-    balance: '0.23645412',
-    description: 'Deposit (BITCOIN) #2168494 on wallet Exchange',
-    timestamp: '1497404114.0' },
+		amount: '0.13074219',
+		balance: '0.23645412',
+		description: 'Deposit (BITCOIN) #2168494 on wallet Exchange',
+		timestamp: '1497404114.0' },
 { currency: 'BTC',
-    amount: '-0.0001',
-    balance: '0.35064598',
-    description: 'Crypto Withdrawal fee on wallet Exchange',
-    timestamp: '1496812280.0' },
-  { currency: 'BTC',
-    amount: '-0.11413851',
-    balance: '0.23650747',
-    description: 'Bitcoin Withdrawal #2111748 on wallet Exchange',
-    timestamp: '1496812280.0' },
-  { currency: 'BTC',
-    amount: '-0.00002044',
-    balance: '0.34052538',
-    description: 'Trading fees for 0.956 LTC (LTCBTC) @ 0.0107 on BFX (0.2%) on wallet Exchange',
-    timestamp: '1496812036.0' },
-  { currency: 'BTC',
-    amount: '0.0102206',
-    balance: '0.35074598',
-    description: 'Exchange 0.956 LTC for BTC @ 0.010691 on wallet Exchange',
-    timestamp: '1496812036.0' }
+		amount: '-0.0001',
+		balance: '0.35064598',
+		description: 'Crypto Withdrawal fee on wallet Exchange',
+		timestamp: '1496812280.0' },
+	{ currency: 'BTC',
+		amount: '-0.11413851',
+		balance: '0.23650747',
+		description: 'Bitcoin Withdrawal #2111748 on wallet Exchange',
+		timestamp: '1496812280.0' },
+	{ currency: 'BTC',
+		amount: '-0.00002044',
+		balance: '0.34052538',
+		description: 'Trading fees for 0.956 LTC (LTCBTC) @ 0.0107 on BFX (0.2%) on wallet Exchange',
+		timestamp: '1496812036.0' },
+	{ currency: 'BTC',
+		amount: '0.0102206',
+		balance: '0.35074598',
+		description: 'Exchange 0.956 LTC for BTC @ 0.010691 on wallet Exchange',
+		timestamp: '1496812036.0' }
 ]
 */
 
 /* movements
 { id: 2168494,
-    currency: 'BTC',
-    method: 'BITCOIN',
-    type: 'DEPOSIT',
-    amount: '0.13074219',
-    description: '6c2303a443e1e795afd66a8dc9659636ff6a1a398ed99fd89e45b15f75421fc3',
-    address: '1HQuKJDgcR9B6Nd6LWj9ASGyfey3PMpnUZ',
-    status: 'COMPLETED',
-    timestamp: '1497404114.0',
-    txid: '6c2303a443e1e795afd66a8dc9659636ff6a1a398ed99fd89e45b15f75421fc3' },
-  { id: 2111748,
-    currency: 'BTC',
-    method: 'BITCOIN',
-    type: 'WITHDRAWAL',
-    amount: '0.11413851',
-    description: '1CsiZp9xvPJmTPfCUnrvAMby1vdPKMPLP8, txid: f011b549c6231e72c0b369e5659288f642576e18548375f4588e342be34df8ce',
-    address: '1CsiZp9xvPJmTPfCUnrvAMby1vdPKMPLP8',
-    status: 'COMPLETED',
-    timestamp: '1496814182.0',
-    txid: 'f011b549c6231e72c0b369e5659288f642576e18548375f4588e342be34df8ce' }
+		currency: 'BTC',
+		method: 'BITCOIN',
+		type: 'DEPOSIT',
+		amount: '0.13074219',
+		description: '6c2303a443e1e795afd66a8dc9659636ff6a1a398ed99fd89e45b15f75421fc3',
+		address: '1HQuKJDgcR9B6Nd6LWj9ASGyfey3PMpnUZ',
+		status: 'COMPLETED',
+		timestamp: '1497404114.0',
+		txid: '6c2303a443e1e795afd66a8dc9659636ff6a1a398ed99fd89e45b15f75421fc3' },
+	{ id: 2111748,
+		currency: 'BTC',
+		method: 'BITCOIN',
+		type: 'WITHDRAWAL',
+		amount: '0.11413851',
+		description: '1CsiZp9xvPJmTPfCUnrvAMby1vdPKMPLP8, txid: f011b549c6231e72c0b369e5659288f642576e18548375f4588e342be34df8ce',
+		address: '1CsiZp9xvPJmTPfCUnrvAMby1vdPKMPLP8',
+		status: 'COMPLETED',
+		timestamp: '1496814182.0',
+		txid: 'f011b549c6231e72c0b369e5659288f642576e18548375f4588e342be34df8ce' }
 */
 
 /* get_symbols
 [ 'btcusd',
-  'ltcusd',
-  'ltcbtc',
-  'ethusd',
-  'ethbtc',
-  'etcbtc',
-  'etcusd',
-  'rrtusd',
-  'rrtbtc',
-  'zecusd',
-  'zecbtc',
-  'xmrusd',
-  'xmrbtc',
-  'dshusd',
-  'dshbtc',
-  'bccbtc',
-  'bcubtc',
-  'bccusd',
-  'bcuusd',
-  'xrpusd',
-  'xrpbtc',
-  'iotusd',
-  'iotbtc' ]
+	'ltcusd',
+	'ltcbtc',
+	'ethusd',
+	'ethbtc',
+	'etcbtc',
+	'etcusd',
+	'rrtusd',
+	'rrtbtc',
+	'zecusd',
+	'zecbtc',
+	'xmrusd',
+	'xmrbtc',
+	'dshusd',
+	'dshbtc',
+	'bccbtc',
+	'bcubtc',
+	'bccusd',
+	'bcuusd',
+	'xrpusd',
+	'xrpbtc',
+	'iotusd',
+	'iotbtc' ]
 
 */

--- a/lib/exchanges/bitfinex.js
+++ b/lib/exchanges/bitfinex.js
@@ -12,137 +12,251 @@ const keys = require('../../api-key')['bitfinex'];
 const bitfinex = new Bitfinex(keys.api_key, keys.api_secret);
 Promise.promisifyAll(bitfinex.rest);
 
-const currencies = {};
-const mt = moment().subtract(5, 'months');
-const ts = mt.format('X') + '.0';
+module.exports = {
+	/* Sample output
+	"LTC": {
+	    "exchange": "gdax",
+	    "currency": "LTC",
+	    "trx": [
+	    	{ exchange: 'bitfinex',
+			  type: 'buy',
+			  currency: 'LTC',
+			  amount: 67,
+			  change: 67,
+			  price: 7.79,
+			  price_currency: 'USD',
+			  date: 2017-03-30T13:48:30.000Z,
+			  ts: 1490881710000,
+			  fee: -0.939474,
+			  fee_currency: 'USD',
+			  pair: 'LTC_USD',
+			  tid: 28199944,
+			  order_id: 2198456451
+			},
+	    	{ exchange: 'bitfinex',
+			  type: 'withdrawal',
+			  currency: 'LTC',
+			  amount: 4.93478977,
+			  change: -4.93478977,
+			  date: 2017-06-18T15:53:26.000Z,
+			  ts: 1497801206000,
+			  balance: 0.001,
+			  description: 'Litecoin Withdrawal #2220674 on wallet Exchange',
+			  movement_id: 2220674,
+			  move:
+			   { type: 'withdrawal',
+			     currency: 'LTC',
+			     amount: 4.93478977,
+			     change: -4.93478977,
+			     date: 2017-06-18T16:05:19.000Z,
+			     ts: 1497801919000,
+			     description: 'LeH2NubB5WBKRP7Zo5hSCiHaY7m2jB7142, txid: 2ae8fac43261ce9e64e93b05593e3c6e7d49ef6e3f6a13a8b03f0cc0c2de67fc',
+			     address: 'LeH2NubB5WBKRP7Zo5hSCiHaY7m2jB7142',
+			     txid: '2ae8fac43261ce9e64e93b05593e3c6e7d49ef6e3f6a13a8b03f0cc0c2de67fc' }
+			},
+			...
+	    ]
+	},
+	"XRP": {
+		"exchange": "gdax",
+	    "currency": "LTC",
+	    "trx": [
+	    	{ exchange: 'bitfinex',
+			  type: 'sell',
+			  currency: 'XRP',
+			  amount: 455.99466052,
+			  change: -455.99466052,
+			  date: 2017-06-17T17:08:00.000Z,
+			  ts: 1497719280000,
+			  balance: 0,
+			  description: 'Exchange 455.99466052 XRP for BTC @ 0.00009823 on wallet Exchange',
+			  price_rnd: 0.00009823,
+			  price_currency: 'BTC',
+			  pair: 'XRP_BTC'
+			},
+			{ exchange: 'bitfinex',
+			  type: 'despoit',
+			  currency: 'XRP',
+			  amount: 10913.368717,
+			  change: 10913.368717,
+			  date: 2017-05-19T23:24:51.000Z,
+			  ts: 1495236291000,
+			  balance: 10913.368717,
+			  description: 'Deposit (RIPPLE) #2006390 on wallet Exchange',
+			  movement_id: 2006390,
+			  move:
+			   { type: 'deposit',
+			     currency: 'XRP',
+			     amount: 10913.368717,
+			     change: -10913.368717,
+			     date: 2017-05-19T23:24:51.000Z,
+			     ts: 1495236291000,
+			     description: '5EBD60066092773329BD8C0071E5268D530CED20A38112F3BAB76375D0186F19',
+			     address: '2686957462',
+			     txid: '5EBD60066092773329BD8C0071E5268D530CED20A38112F3BAB76375D0186F19' }
+			},
+			...
+	    ]
+	}
+	*/
+	getAllTransactions: () => {
+		const currencies = {};
+		const moves = {};
+		const unusedMoves = {};
+		const mt = moment().subtract(5, 'months');
+		const ts = mt.format('X') + '.0';
 
-//return bitfinex.rest.past_tradesAsync('btcusd')
-//return bitfinex.rest.balance_historyAsync('btc')
-//return bitfinex.rest.movementsAsync('btc')
-return bitfinex.rest.get_symbolsAsync()
-	.then(markets => {
-		const currTrades = [];
-		//return Promise.each(markets, market => {
-		return Promise.each(['ltcusd', 'ltcbtc', 'xrpusd', 'xrpbtc'], market => {
-			const targetCurr = market.substr(0, 3).toUpperCase();
-			const sourceCurr = market.substr(3, 3).toUpperCase();
-			return bitfinex.rest.past_tradesAsync(market, { timestamp: ts, limit_trades: 1000 })
-				.then(trades => {
-					currTrades.push({
-						targetCurr: targetCurr,
-						sourceCurr: sourceCurr,
-						trades: trades
-					});
+		return bitfinex.rest.get_symbolsAsync()
+			.then(markets => {
+				const currTrades = [];
+				//return Promise.each(['ltcusd', 'ltcbtc', 'xrpusd', 'xrpbtc'], market => {
+				return Promise.each(markets, market => {
+					const targetCurr = market.substr(0, 3).toUpperCase();
+					const sourceCurr = market.substr(3, 3).toUpperCase();
+					return bitfinex.rest.past_tradesAsync(market, { timestamp: ts, limit_trades: 1000 })
+						.then(trades => {
+							currTrades.push({
+								targetCurr: targetCurr,
+								sourceCurr: sourceCurr,
+								trades: trades
+							});
+						});
+				})
+				.then(() => {
+					return currTrades;
 				});
-		})
-		.then(() => {
-			return currTrades;
-		});
-	})
-	.then(currencyTrades => {
-		currencyTrades.forEach(currData => {
-			const currency = currData.targetCurr;
-			const sourceCurr = currData.sourceCurr;
-			if (!currencies[currency]) {
-				currencies[currency] = {
-					exchange: 'bitfinex',
-					currency: currency,
-					trades: {}
-				};
-			}
-			currencies[currency].trades[sourceCurr] = currData.trades.map(trade => {
-				const dt = moment(trade.timestamp, 'X');
-				const amt = parseNum(trade.amount);
-				const netAmount = trade.type.toLowerCase() === 'buy' ? amt : 0 - amt;
-				return {
-					exchange: 'bitfinex',
-					type: trade.type.toLowerCase(),
-					currency: currency,
-					amount: amt,
-					change: netAmount,
-					price: parseNum(trade.price),
-					price_currency: sourceCurr,
-					date: dt.toDate(),
-					ts: +dt,
-					fee: parseNum(trade.fee_amount),
-					fee_currency: trade.fee_currency,
-					pair: `${currency.toUpperCase()}_${sourceCurr.toUpperCase()}`,
-					tid: trade.tid,
-					order_id: trade.order_id
-				};
-			});
-		});
-		return Promise.each(Object.keys(currencies), currency => {
-			return bitfinex.rest.balance_historyAsync(currency.toLowerCase(), { since: ts, limit: 2000 })
-				.then(history => {
-					currencies[currency].history = history.map(trade => {
+			})
+			.then(currencyTrades => {
+				currencyTrades.forEach(currData => {
+					const currency = currData.targetCurr;
+					const sourceCurr = currData.sourceCurr;
+					if (!currencies[currency]) {
+						currencies[currency] = {
+							exchange: 'bitfinex',
+							currency: currency,
+							trx: []
+						};
+					}
+					currData.trades.forEach(trade => {
 						const dt = moment(trade.timestamp, 'X');
 						const amt = parseNum(trade.amount);
-						const parts = trade.description.split(' ');
+						const netAmount = trade.type.toLowerCase() === 'buy' ? amt : 0 - amt;
 						const trx = {
 							exchange: 'bitfinex',
-							type: '?',
-							currency: trade.currency,
-							amount: Math.abs(amt),
-							change: amt,
+							type: trade.type.toLowerCase(),
+							currency: currency,
+							amount: amt,
+							change: netAmount,
+							price: parseNum(trade.price),
+							price_currency: sourceCurr,
 							date: dt.toDate(),
 							ts: +dt,
-							balance: parseNum(trade.balance),
-							description: trade.description
+							fee: parseNum(trade.fee_amount),
+							fee_currency: trade.fee_currency,
+							pair: `${currency.toUpperCase()}_${sourceCurr.toUpperCase()}`,
+							tid: trade.tid,
+							order_id: trade.order_id
 						};
-						if (parts[0] === 'Deposit') {
-							trx.type = 'despoit';
-							trx.movement_id = parseNum(parts[2].substr(1,7));
-							console.log(`++ deposit ${trx.movement_id} ! (${trade.description})`);
-							console.log('    ' + JSON.stringify(trx));
-						} else if (parts[1] === 'Withdrawal' && parts[2] !== 'fee') {
-							trx.type = 'withdrawal';
-							trx.movement_id = parseNum(parts[2].substr(1,7));
-							console.log(`++ withdrawal ${trx.movement_id} ! (${trade.description})`);
-							console.log('    ' + JSON.stringify(trx));
-						} else if (parts[0] === 'Exchange') {
-							trx.type = (amt > 0) ? 'buy' : 'sell';
-							trx.price_rnd = parseNum(parts[6]);
-							trx.price_currency = parts[4];
-							trx.pair = `${currency}_${trx.price_currency}`;
-							console.log(trade.description);
-							console.log('    ' + JSON.stringify(trx));
-						} else {
-							console.log(trade.description);
-						}
+						currencies[currency].trx.push(trx);
 					});
-					return bitfinex.rest.movementsAsync(currency.toLowerCase(), { since: ts, limit: 2000 });
-				})
-				.then(movements => {
-					currencies[currency].movements = movements;
-					return Promise.resolve(currencies[currency]);
 				});
-		});
-	})
-	.then(() => {
-		const summary = {};
-		Object.keys(currencies).forEach(currency => {
-			const currInfo = currencies[currency];
-			summary[currency] = {
-				trades: [],
-				history: currInfo.history.length,
-				movements: currInfo.movements.length
-			};
-			Object.keys(currInfo.trades).forEach(otherCurr => {
-				summary[currency].trades.push({
-					pair: `${currency}_${otherCurr}`,
-					trades: currInfo.trades[otherCurr].length
+				return Promise.each(Object.keys(currencies), currency => {
+					return bitfinex.rest.movementsAsync(currency.toLowerCase(), { since: ts, limit: 2000 })
+						.then(movements => {
+							movements.forEach(move => {
+								if (moves[move.id]) {
+									console.error(`Duplicate move ${move.id}`);
+									console.error(JSON.stringify(move));
+								}
+								moves[move.id] = move;
+								unusedMoves[move.id] = true;
+							});
+							return bitfinex.rest.balance_historyAsync(currency.toLowerCase(), { since: ts, limit: 2000 })
+						})
+						.then(history => {
+							if (!currencies[currency]) {
+								currencies[currency] = {
+									exchange: 'bitfinex',
+									currency: currency,
+									trx: []
+								};
+							}
+							history.forEach(trade => {
+								const dt = moment(trade.timestamp, 'X');
+								const amt = parseNum(trade.amount);
+								const parts = trade.description.split(' ');
+								const trx = {
+									exchange: 'bitfinex',
+									type: '?',
+									currency: trade.currency,
+									amount: Math.abs(amt),
+									change: amt,
+									date: dt.toDate(),
+									ts: +dt,
+									balance: parseNum(trade.balance),
+									description: trade.description
+								};
+								if (parts[0] === 'Deposit' || (parts[1] === 'Withdrawal' && parts[2] !== 'fee')) {
+									trx.type = parts[0] === 'Deposit' ? 'despoit' : 'withdrawal';
+									trx.movement_id = parseNum(parts[2].substr(1,7));
+									if (!moves[trx.movement_id]) {
+										console.error(`Missing move ${trx.movement_id} for trx`);
+										console.error(JSON.stringify(trx, null, 2));
+									}
+									const theMove = moves[trx.movement_id];
+									unusedMoves[trx.movement_id] = false;
+									const moveDt = moment(theMove.timestamp, 'X');
+									const amt = parseNum(theMove.amount);
+									trx.move = {
+										type: theMove.type.toLowerCase(),
+										currency: currency,
+										amount: amt,
+										change: trx.type === 'deposit' ? amt : (0 - amt),
+										date: moveDt.toDate(),
+										ts: +moveDt,
+										description: theMove.description,
+										address: theMove.address,
+										txid: theMove.txid
+									};
+									//console.log(`++ deposit ${trx.movement_id} ! (${trade.description})`);
+									//console.log('    ' + JSON.stringify(trx));
+								} else if (parts[0] === 'Exchange') {
+									trx.type = (amt > 0) ? 'buy' : 'sell';
+									trx.price_rnd = parseNum(parts[6]);
+									trx.price_currency = parts[4];
+									trx.pair = `${currency}_${trx.price_currency}`;
+									//console.log(trade.description);
+									//console.log('    ' + JSON.stringify(trx));
+								} else if (parts[1] === 'fees') {
+									trx.type = 'fee';
+									trx.pair = `${currency}_${parts[5].substr(4,3)}`;
+									//console.log(trade.description);
+									//console.log('    ' + JSON.stringify(trx));
+								} else if (parts[0] === 'Settlement') {
+									trx.type = 'settlement';
+									//console.log(trade.description);
+									//console.log('    ' + JSON.stringify(trx));
+								} else if (parts[0] === 'Crypto' && parts[1] === 'Withdrawal') {
+									trx.type = 'fee-withdrawal';
+								} else {
+									//console.log('@@@@@@@' + trade.description);
+									//console.log('  ' + JSON.stringify(trade));
+									return;
+								}
+								currencies[currency].trx.push(trx);
+							});
+							currencies[currency].trx.sort((x, y) => {
+								return (+x.date) - (+y.date);
+							});
+							return Promise.resolve(currencies[currency]);
+						});
 				});
+			})
+			.then(() => {
+				return currencies;
 			});
-		});
-		console.log(JSON.stringify(summary, null, 2));
-		process.exit();
-	})
-	.catch(err => {
-		console.error(err);
-		process.exit();
-	});
-
+	}
+};
 
 
 /* past_trades

--- a/lib/exchanges/bitfinex.js
+++ b/lib/exchanges/bitfinex.js
@@ -140,7 +140,11 @@ module.exports = {
 					currData.trades.forEach(trade => {
 						const dt = moment(trade.timestamp, 'X');
 						const amt = parseNum(trade.amount);
-						const netAmount = trade.type.toLowerCase() === 'buy' ? amt : 0 - amt;
+						let netAmount = trade.type.toLowerCase() === 'buy' ? amt : 0 - amt;
+						const fee = parseNum(trade.fee_amount);
+						if (trade.fee_currency === currency) {
+							netAmount += fee;
+						}
 						const trx = {
 							exchange: 'bitfinex',
 							type: trade.type.toLowerCase(),
@@ -151,7 +155,7 @@ module.exports = {
 							price_currency: sourceCurr,
 							date: dt.toDate(),
 							ts: +dt,
-							fee: parseNum(trade.fee_amount),
+							fee: fee,
 							fee_currency: trade.fee_currency,
 							pair: `${currency.toUpperCase()}_${sourceCurr.toUpperCase()}`,
 							tid: trade.tid,
@@ -225,11 +229,13 @@ module.exports = {
 									trx.price_rnd = parseNum(parts[6]);
 									trx.price_currency = parts[4];
 									trx.pair = `${currency}_${trx.price_currency}`;
+									return;
 									//console.log(trade.description);
 									//console.log('    ' + JSON.stringify(trx));
 								} else if (parts[1] === 'fees') {
 									trx.type = 'fee';
 									trx.pair = `${currency}_${parts[5].substr(4,3)}`;
+									return;
 									//console.log(trade.description);
 									//console.log('    ' + JSON.stringify(trx));
 								} else if (parts[0] === 'Settlement') {

--- a/lib/exchanges/bitstamp.js
+++ b/lib/exchanges/bitstamp.js
@@ -1,0 +1,198 @@
+const Promise = require('bluebird');
+const moment = require('moment');
+const _ = require('lodash');
+const parseNum = require('parse-decimal-number');
+
+const Bitstamp = require('bitstamp-promise');
+const keys = require('../../api-key')['bitstamp'];
+
+const bitstamp = new Bitstamp(keys.api_key, keys.api_secret, keys.client_id);
+
+const trxCurrencyProps = ['usd', 'eur', 'btc', 'xrp', 'ltc'];
+const trxPairs = [
+	{ name: 'btc_usd', currency: 'btc', price_currency: 'usd' },
+	{ name: 'btc_eur', currency: 'btc', price_currency: 'eur' },
+	{ name: 'xrp_btc', currency: 'xrp', price_currency: 'btc' },
+	{ name: 'xrp_usd', currency: 'xrp', price_currency: 'usd' },
+	{ name: 'xrp_eur', currency: 'xrp', price_currency: 'eur' },
+	{ name: 'ltc_btc', currency: 'ltc', price_currency: 'btc' },
+	{ name: 'ltc_usd', currency: 'ltc', price_currency: 'usd' },
+	{ name: 'ltc_eur', currency: 'ltc', price_currency: 'eur' }
+];
+
+const parseNumSafe = (val) => {
+	if (typeof val === 'number') {
+		return val;
+	}
+	return parseNum(val);
+};
+
+module.exports = {
+	getAllTransactions: () => {
+		return bitstamp.user_transactions(null, { limit: 1000 })
+			.then(raw => {
+				const currencies = {};
+				raw.forEach(rawTrx => {
+					const dt = moment(rawTrx['datetime']),
+						trx = {
+							exchange: 'bitstamp',
+							type: '',
+							currency: '',
+							date: dt.toDate(),
+							ts: +dt,
+							amount: 0,
+							change: 0,
+							fill: rawTrx
+						};
+					if (rawTrx['type'] === '0') {
+						trx.type = 'deposit';
+						trxCurrencyProps.some(currency => {
+							if (rawTrx[currency]) {
+								let amt = parseNum(rawTrx[currency]);
+								if (amt > 0) {
+									trx.currency = currency.toUpperCase();
+									trx.amount = trx.change = amt;
+									return true;
+								}
+							}
+							return false;
+						});
+					} else if (rawTrx['type'] === '1') {
+						trx.type = 'withdrawal';
+						trxCurrencyProps.some(currency => {
+							if (rawTrx[currency]) {
+								let amt = parseNum(rawTrx[currency]);
+								if (amt < 0) {
+									trx.currency = currency.toUpperCase();
+									trx.change = amt;
+									trx.amount = Math.abs(amt);
+									return true;
+								}
+							}
+							return false;
+						});
+					} else if (rawTrx['type'] === '2') {
+						let pairData = null;
+						trxPairs.some(pair => {
+							if (rawTrx[pair.name] && parseNumSafe(rawTrx[pair.name]) !== 0) {
+								trx.currency = pair.currency.toUpperCase();
+								trx.price_currency = trx.fee_currency = pair.price_currency.toUpperCase();
+								trx.price = parseNumSafe(rawTrx[pair.name]);
+								trx.cost = Math.abs(parseNumSafe(rawTrx[pair.price_currency]));
+								trx.fee = parseNumSafe(rawTrx['fee']);
+
+								trx.change = parseNumSafe(rawTrx[pair.currency]);
+								trx.amount = Math.abs(trx.change);
+								if (trx.change < 0) {
+									trx.type = 'sell';
+								} else {
+									trx.type = 'buy';
+								}
+							}
+						})
+					}
+
+					if (trx.currency) {
+						if (!currencies[trx.currency]) {
+							currencies[trx.currency] = {
+								exchange: 'bitstamp',
+								currency: trx.currency,
+								trx: []
+							};
+						}
+						currencies[trx.currency].trx.push(trx);
+					}
+				});
+
+				Object.keys(currencies).forEach(currency => {
+					const data = currencies[currency];
+					data.trx.sort((x, y) => {
+						return (+x.date) - (+y.date);
+					});
+				});
+
+				return currencies;
+			});
+	}
+};
+
+/*
+datetime			Date and time.
+id					Transaction ID.
+type				Transaction type: 0 - deposit; 1 - withdrawal; 2 - market trade; 14 - sub account transfer.
+usd					USD amount.
+eur (v2 calls only)	EUR amount.
+btc					BTC amount.
+xrp (v2 calls only)	XRP amount.
+btc_usd or btc_eur	Exchange rate.
+fee					Transaction fee.
+order_id			Executed order ID.
+*/
+
+/* Sample Transaction
+{
+    "usd": "4815.00",
+    "btc_usd": 2140,
+    "order_id": 9096764,
+    "datetime": "2017-05-23 03:00:09",
+    "fee": "12.04000000",
+    "btc": "-2.25000000",
+    "type": "2",
+    "id": 15146943,
+    "eur": 0
+  },
+  {
+    "fee": "0.00000000",
+    "btc_usd": "0.00",
+    "datetime": "2017-05-23 02:24:52",
+    "usd": 0,
+    "btc": "2.25000000",
+    "type": "0",
+    "id": 15146448,
+    "eur": 0
+  },
+  {
+    "fee": "0.00000000",
+    "btc_usd": "0.00",
+    "datetime": "2017-05-23 01:00:25",
+    "usd": 0,
+    "btc": "-2.90126896",
+    "type": "1",
+    "id": 15145457,
+    "eur": 0
+  },
+  {
+    "fee": "0.00000000",
+    "btc_usd": "0.00",
+    "id": 15034239,
+    "usd": 0,
+    "btc": 0,
+    "datetime": "2017-05-20 00:56:11",
+    "type": "1",
+    "xrp": "-10813.36871700",
+    "eur": 0
+  },
+  {
+    "fee": "0.00000000",
+    "btc_usd": "0.00",
+    "id": 15034227,
+    "usd": 0,
+    "btc": 0,
+    "datetime": "2017-05-20 00:54:12",
+    "type": "0",
+    "xrp": "10713.36871700",
+    "eur": 0
+  },
+  {
+    "fee": "0.00029000",
+    "order_id": 213399142,
+    "id": 14142861,
+    "usd": 0,
+    "xrp_btc": 0.000029,
+    "btc": "0.11793052",
+    "datetime": "2017-04-10 17:20:49",
+    "type": "2",
+    "xrp": "-4066.56970700",
+    "eur": 0
+  },
+*/

--- a/lib/exchanges/bitstamp.js
+++ b/lib/exchanges/bitstamp.js
@@ -33,7 +33,7 @@ module.exports = {
 			.then(raw => {
 				const currencies = {};
 				raw.forEach(rawTrx => {
-					const dt = moment(rawTrx['datetime']),
+					const dt = moment.utc(rawTrx['datetime']),
 						trx = {
 							exchange: 'bitstamp',
 							type: '',

--- a/lib/exchanges/bittrex.js
+++ b/lib/exchanges/bittrex.js
@@ -6,6 +6,7 @@ const parseNum = require('parse-decimal-number');
 const bittrexAPI = require('@you21979/bittrex.com');
 const keys = require('../../api-key')['bittrex'];
 const bittrex = bittrexAPI.createPrivateApi(keys.api_key, keys.api_secret, 'I am Bot');
+const bittrexPub = bittrexAPI.PublicApi;
 
 module.exports = {
 	/* Sample output
@@ -128,7 +129,7 @@ module.exports = {
 		const currencies = {};
 
 		return Promise.all([
-			bittrex.getOrderHistory(),
+			module.exports.getFullOrderHistory(),
 			bittrex.getWithdrawalHistory(),
 			bittrex.getDepositHistory()
 		])
@@ -145,8 +146,11 @@ module.exports = {
 					typeParts = order['OrderType'].split('_'),
 					type = typeParts[1] === 'SELL' ? 'sell' : 'buy',
 					dt = moment.utc(order['Closed']),
-					dtCreated = moment.utc(order['TimeStamp']),
-					amount = order['Quantity'];
+					dtCreated = moment.utc(order['TimeStamp']);
+				let amount = order['Quantity'];
+				if (order['QuantityRemaining']) {
+					amount -= order['QuantityRemaining'];
+				}
 				if (type === 'buy' && typeParts[1] !== 'BUY') {
 					console.log(`!!!!!!!!! UNKNOWN TYPE: ${order['OrderType']} !!!!!!!!!!!!!`);
 				}
@@ -238,6 +242,113 @@ module.exports = {
 
 			return currencies;
 		});
+	},
+
+	getMarkets: () => {
+		return bittrexPub.getMarkets()
+	},
+
+	getOldOrderHistory: () => {
+		/*
+		const CSVReader = require('promised-csv');
+		const reader = new CSVReader(true);
+		let skip = true;
+		return reader.read('./local/bittrex-order-history.csv', row => {
+			if (skip) {
+				skip = false;
+				return null;
+			}
+			const amount = (typeof row[3] === 'string') ? parseNum(row[3]) : row[3],
+				cost = (typeof row[6] === 'string') ? parseNum(row[6]) : row[6],
+				price = (amount === 0) ? 0 : (cost / amount);
+			return {
+				OrderUuid: row[0],
+				Exchange: row[1],
+				TimeStamp: row[7],
+				OrderType: row[2],
+				Limit: row[4],
+				Quantity: amount,
+				Commission: row[5],
+				Price: cost,
+				PricePerUnit: price,
+				Closed: row[8]
+			};
+		})
+		.then(rows => {
+			return rows;
+		});*/
+		const fs = require('fs');
+		const csv = require('csv-parser');
+		const trans = [];
+
+		return new Promise((resolve, reject) => {
+			fs.createReadStream('./local/bittrex-order-history.csv', "utf16le")
+				.pipe(csv())
+				.on('data', (data) => {
+					const amount = (typeof data['Quantity'] === 'string') ? parseNum(data['Quantity']) : data['Quantity'],
+						cost = (typeof data['Price'] === 'string') ? parseNum(data['Price']) : data['Price'],
+						price = (amount === 0) ? 0 : (cost / amount);
+					trans.push({
+						OrderUuid: data['OrderUuid'],
+						Exchange: data['Exchange'],
+						TimeStamp: data['Opened'],
+						OrderType: data['Type'],
+						Limit: data['Limit'],
+						Quantity: amount,
+						Commission: data['CommissionPaid'],
+						Price: cost,
+						PricePerUnit: price,
+						Closed: data['Closed']
+					});
+				})
+				.on('end', () => {
+					resolve(trans);
+				})
+				.on('error', () => {
+					reject({});
+				});
+		});
+	},
+
+	getFullOrderHistory: () => {
+		return Promise.all([
+			module.exports.getOldOrderHistory(),
+			module.exports.getMarkets()
+		])
+			.then(res => {
+				const oldOrders = res[0];
+				const data = res[1];
+				const batches = [];
+				let numBatches = Math.max(10, Math.ceil(data.length / 10));
+				for (let i = 0; i < data.length; i += Math.ceil(data.length / numBatches)) {
+					const end = i + Math.ceil(data.length / numBatches);
+					batches.push(data.slice(i, Math.min(data.length, end)));
+				}
+
+				return Promise.reduce(batches, function(history, batch) {
+					return Promise.all(batch.map(market => {
+						return bittrex.getOrderHistory({ market: market['MarketName'] })
+					}))
+						.then(allRes => {
+							allRes.forEach(res => {
+								history = history.concat(res);
+							});
+							return Promise.delay(100, history);
+						});
+				}, [])
+					.then(orders => {
+						const map = {};
+						orders.forEach(order => {
+							map[order['OrderUuid']] = true;
+						});
+						oldOrders.forEach(order => {
+							if(!map[order['OrderUuid']]) {
+								orders.push(order);
+							}
+						});
+						return orders;
+					});
+			});
 	}
 };
 

--- a/lib/exchanges/bittrex.js
+++ b/lib/exchanges/bittrex.js
@@ -1,0 +1,307 @@
+const Promise = require('bluebird');
+const moment = require('moment');
+const _ = require('lodash');
+const parseNum = require('parse-decimal-number');
+
+const bittrexAPI = require('@you21979/bittrex.com');
+const keys = require('../../api-key')['bittrex'];
+const bittrex = bittrexAPI.createPrivateApi(keys.api_key, keys.api_secret, 'I am Bot');
+
+module.exports = {
+	/* Sample output
+	"NAV": {
+	    "exchange": "bittrex",
+	    "currency": "NAV",
+	    "trx": [
+	      {
+	        "exchange": "bittrex",
+	        "type": "deposit",
+	        "currency": "NAV",
+	        "date": "2017-06-12T09:52:17.243Z",
+	        "ts": 1497261137243,
+	        "amount": 499.90557172,
+	        "change": 499.90557172,
+	        "fill": {
+	          "Id": 19851266,
+	          "Amount": 499.90557172,
+	          "Currency": "NAV",
+	          "Confirmations": 28,
+	          "LastUpdated": "2017-06-12T05:52:17.243",
+	          "TxId": "2ab342ac7841cf400ca94581ba310da59161774068e658b2ea5fd9745d78bbc4",
+	          "CryptoAddress": "NRLMg9HhW2uonJVWiqtYrj1FimhjYzR1Gw"
+	        }
+	      },
+	      {
+	        "exchange": "bittrex",
+	        "type": "sell",
+	        "currency": "NAV",
+	        "date": "2017-06-12T17:28:08.620Z",
+	        "ts": 1497288488620,
+	        "amount": 499.90557172,
+	        "change": -499.90557172,
+	        "date_created": "2017-06-12T17:28:08.400Z",
+	        "ts_created": 1497288488400,
+	        "price": 0.00013412,
+	        "price_currency": "BTC",
+	        "cost": 0.06705233,
+	        "fee": 0.00016762,
+	        "fee_currency": "BTC",
+	        "fill": {
+	          "OrderUuid": "cce3a25b-bd19-4805-923c-0eb78cfdce75",
+	          "Exchange": "BTC-NAV",
+	          "TimeStamp": "2017-06-12T13:28:08.4",
+	          "OrderType": "LIMIT_SELL",
+	          "Limit": 0.00013369,
+	          "Quantity": 499.90557172,
+	          "QuantityRemaining": 0,
+	          "Commission": 0.00016762,
+	          "Price": 0.06705233,
+	          "PricePerUnit": 0.00013412,
+	          "IsConditional": false,
+	          "Condition": "NONE",
+	          "ConditionTarget": null,
+	          "ImmediateOrCancel": false,
+	          "Closed": "2017-06-12T13:28:08.62"
+	        }
+	      },
+	      {
+	        "exchange": "bittrex",
+	        "type": "buy",
+	        "currency": "NAV",
+	        "date": "2017-06-20T08:19:02.727Z",
+	        "ts": 1497946742727,
+	        "amount": 1371.54878451,
+	        "change": 1371.54878451,
+	        "date_created": "2017-06-20T08:19:02.647Z",
+	        "ts_created": 1497946742647,
+	        "price": 0.00018181,
+	        "price_currency": "BTC",
+	        "cost": 0.24937499,
+	        "fee": 0.00062343,
+	        "fee_currency": "NAV",
+	        "fill": {
+	          "OrderUuid": "7bd30f22-854d-4fac-8db0-66315d8c3bfd",
+	          "Exchange": "BTC-NAV",
+	          "TimeStamp": "2017-06-20T04:19:02.647",
+	          "OrderType": "LIMIT_BUY",
+	          "Limit": 0.00018182,
+	          "Quantity": 1371.54878451,
+	          "QuantityRemaining": 0,
+	          "Commission": 0.00062343,
+	          "Price": 0.24937499,
+	          "PricePerUnit": 0.00018181,
+	          "IsConditional": false,
+	          "Condition": "NONE",
+	          "ConditionTarget": null,
+	          "ImmediateOrCancel": false,
+	          "Closed": "2017-06-20T04:19:02.727"
+	        }
+	      },
+	      {
+	        "exchange": "bittrex",
+	        "type": "withdrawal",
+	        "currency": "NAV",
+	        "date": "2017-06-20T08:20:23.447Z",
+	        "ts": 1497946823447,
+	        "amount": 1371.34878451,
+	        "change": -1371.34878451,
+	        "fee": 0.2,
+	        "fee_currency": "NAV",
+	        "fill": {
+	          "PaymentUuid": "05d163fb-702d-4b25-9f7e-cd1930fab7a6",
+	          "Currency": "NAV",
+	          "Amount": 1371.34878451,
+	          "Address": "NQd72yZmKo7UXLqNff4PU2MEbe8EzN1eFf",
+	          "Opened": "2017-06-20T04:20:23.447",
+	          "Authorized": true,
+	          "PendingPayment": false,
+	          "TxCost": 0.2,
+	          "TxId": "4411f5ad1020521b3bc35b580dbd18f3d3e306421c703af4e80cf40107b47d8a",
+	          "Canceled": false,
+	          "InvalidAddress": false
+	        }
+	      }
+	    ]
+	  },
+	*/
+	getAllTransactions: () => {
+		const currencies = {};
+
+		return Promise.all([
+			bittrex.getOrderHistory(),
+			bittrex.getWithdrawalHistory(),
+			bittrex.getDepositHistory()
+		])
+		.then(res => {
+			const orders = res[0],
+				withdrawals = res[1],
+				deposits = res[2];
+
+			/* Orders */
+			orders.forEach(order => {
+				const pairParts = order['Exchange'].split('-'),
+					currency = pairParts[1],
+					priceCurrency = pairParts[0],
+					typeParts = order['OrderType'].split('_'),
+					type = typeParts[1] === 'SELL' ? 'sell' : 'buy',
+					dt = moment(order['Closed']),
+					dtCreated = moment(order['TimeStamp']),
+					amount = order['Quantity'];
+				if (type === 'buy' && typeParts[1] !== 'BUY') {
+					console.log(`!!!!!!!!! UNKNOWN TYPE: ${order['OrderType']} !!!!!!!!!!!!!`);
+				}
+				const trx = {
+					exchange: 'bittrex',
+					type: type,
+					currency: currency,
+					date: dt.toDate(),
+					ts: +dt,
+					amount: amount,
+					change: type === 'sell' ? (0 - amount) : amount,
+					date_created: dtCreated.toDate(),
+					ts_created: +dtCreated,
+					price: order['PricePerUnit'],
+					price_currency: priceCurrency,
+					cost: order['Price'],
+					fee: order['Commission'],
+					fee_currency: type === 'sell' ? priceCurrency : currency,
+					fill: order
+				};
+				if (!currencies[currency]) {
+					currencies[currency] = {
+						exchange: 'bittrex',
+						currency: currency,
+						trx: []
+					};
+				}
+				currencies[currency].trx.push(trx);
+			});
+
+			/* Withdrawals */
+			withdrawals.forEach(order => {
+				const currency = order['Currency'],
+					amount = order['Amount'],
+					dt = moment(order['Opened']);
+				const trx = {
+					exchange: 'bittrex',
+					type: 'withdrawal',
+					currency: currency,
+					date: dt.toDate(),
+					ts: +dt,
+					amount: amount,
+					change: 0 - amount,
+					fee: order['TxCost'],
+					fee_currency: currency,
+					fill: order
+				};
+				if (!currencies[currency]) {
+					currencies[currency] = {
+						exchange: 'bittrex',
+						currency: currency,
+						trx: []
+					};
+				}
+				currencies[currency].trx.push(trx);
+			});
+
+			/* Deposits */
+			deposits.forEach(order => {
+				const currency = order['Currency'],
+					amount = order['Amount'],
+					dt = moment(order['LastUpdated']);
+				const trx = {
+					exchange: 'bittrex',
+					type: 'deposit',
+					currency: currency,
+					date: dt.toDate(),
+					ts: +dt,
+					amount: amount,
+					change: amount,
+					fill: order
+				};
+				if (!currencies[currency]) {
+					currencies[currency] = {
+						exchange: 'bittrex',
+						currency: currency,
+						trx: []
+					};
+				}
+				currencies[currency].trx.push(trx);
+			});
+
+			Object.keys(currencies).forEach(currency => {
+				const data = currencies[currency];
+				data.trx.sort((x, y) => {
+					return (+x.date) - (+y.date);
+				});
+			});
+
+			return currencies;
+		});
+	}
+};
+
+/* Sample Orders
+{
+	"OrderUuid": "324dd5dd-8ae9-4461-b9d3-fcb23ce8af67",
+	"Exchange": "BTC-8BIT",
+	"TimeStamp": "2017-06-23T23:25:27.46",
+	"OrderType": "LIMIT_SELL",
+	"Limit": 0.00008133,
+	"Quantity": 1520.94764605,
+	"QuantityRemaining": 0,
+	"Commission": 0.00031305,
+	"Price": 0.12522873,
+	"PricePerUnit": 0.00008233,
+	"IsConditional": false,
+	"Condition": "NONE",
+	"ConditionTarget": null,
+	"ImmediateOrCancel": false,
+	"Closed": "2017-06-23T23:25:27.587"
+},
+{
+	"OrderUuid": "a9166f3f-0284-45af-a7ae-140e7818562b",
+	"Exchange": "BTC-8BIT",
+	"TimeStamp": "2017-06-23T23:15:06.74",
+	"OrderType": "LIMIT_BUY",
+	"Limit": 0.00009141,
+	"Quantity": 1520.94764605,
+	"QuantityRemaining": 0,
+	"Commission": 0.00034737,
+	"Price": 0.13895718,
+	"PricePerUnit": 0.00009136,
+	"IsConditional": false,
+	"Condition": "NONE",
+	"ConditionTarget": null,
+	"ImmediateOrCancel": false,
+	"Closed": "2017-06-23T23:15:06.893"
+},
+*/
+
+/* Sample Withdrawal
+{
+  "PaymentUuid": "c6c27f46-cea5-48e1-8af2-fcc66093a5fd",
+  "Currency": "BTC",
+  "Amount": 0.05306175,
+  "Address": "1FBQTNKE1CSkB7TYAEiV8jRmPNmpsEuXXs",
+  "Opened": "2017-06-24T00:05:58.483",
+  "Authorized": true,
+  "PendingPayment": false,
+  "TxCost": 0.001,
+  "TxId": "7c09ce2246cfba11d2ec4b57b52e7f50de5cf31d5b7962f74c803f07a9ac59c3",
+  "Canceled": false,
+  "InvalidAddress": false
+}
+*/
+
+/* Sample Despoit
+{
+  "Id": 20830887,
+  "Amount": 0.60538091,
+  "Currency": "BTC",
+  "Confirmations": 2,
+  "LastUpdated": "2017-06-23T06:40:20.903",
+  "TxId": "ca773612324cb98efea9ac58097cd583e1b062f82815ed3c15614f5bae892540",
+  "CryptoAddress": "15eJvJn9XGJReCRoGWPJgWP45tGkDetuVz"
+},
+*/

--- a/lib/exchanges/bittrex.js
+++ b/lib/exchanges/bittrex.js
@@ -144,8 +144,8 @@ module.exports = {
 					priceCurrency = pairParts[0],
 					typeParts = order['OrderType'].split('_'),
 					type = typeParts[1] === 'SELL' ? 'sell' : 'buy',
-					dt = moment(order['Closed']),
-					dtCreated = moment(order['TimeStamp']),
+					dt = moment.utc(order['Closed']),
+					dtCreated = moment.utc(order['TimeStamp']),
 					amount = order['Quantity'];
 				if (type === 'buy' && typeParts[1] !== 'BUY') {
 					console.log(`!!!!!!!!! UNKNOWN TYPE: ${order['OrderType']} !!!!!!!!!!!!!`);
@@ -181,7 +181,7 @@ module.exports = {
 			withdrawals.forEach(order => {
 				const currency = order['Currency'],
 					amount = order['Amount'],
-					dt = moment(order['Opened']);
+					dt = moment.utc(order['Opened']);
 				const trx = {
 					exchange: 'bittrex',
 					type: 'withdrawal',
@@ -208,7 +208,7 @@ module.exports = {
 			deposits.forEach(order => {
 				const currency = order['Currency'],
 					amount = order['Amount'],
-					dt = moment(order['LastUpdated']);
+					dt = moment.utc(order['LastUpdated']);
 				const trx = {
 					exchange: 'bittrex',
 					type: 'deposit',

--- a/lib/exchanges/bittrex.js
+++ b/lib/exchanges/bittrex.js
@@ -294,7 +294,7 @@ module.exports = {
 }
 */
 
-/* Sample Despoit
+/* Sample Deposit
 {
   "Id": 20830887,
   "Amount": 0.60538091,

--- a/lib/exchanges/coinbase.js
+++ b/lib/exchanges/coinbase.js
@@ -1,0 +1,174 @@
+const Promise = require('bluebird');
+const moment = require('moment');
+const _ = require('lodash');
+const parseNum = require('parse-decimal-number');
+
+const coinbase = require('coinbase');
+const CoinbaseClient = coinbase.Client;
+const CoinbaseAccount = coinbase.model.Account;
+Promise.promisifyAll(CoinbaseClient.prototype);
+Promise.promisifyAll(CoinbaseAccount.prototype, { multiArgs: true });
+
+const keys = require('../../api-key')['coinbase'];
+
+const client = new CoinbaseClient({ apiKey: keys.api_key, apiSecret: keys.api_secret });
+
+const paginateLoop = (results, request, pagination) => {
+	if (pagination && pagination.next_uri) {
+		return paginate(results, request, pagination);
+	} else {
+		return paginate(results, request);
+	}
+};
+
+const paginate = (results, request, pagination) => {
+	return request(pagination).then(res => {
+		if (res[0] && res[0].length) {
+			results = results.concat(res[0]);
+		}
+		if (res[1] && res[1].next_uri) {
+			return paginateLoop(results, request, res[1])
+				.then(allResults => {
+					return allResults;
+				});
+		} else {
+			return Promise.resolve(results);
+		}
+	})
+};
+
+return client.getAccountsAsync({})
+	.then(accts => {
+		return Promise.all(accts.map(acct => {
+			return paginateLoop([], paginationInfo => {
+				return acct.getTransactionsAsync(paginationInfo);
+			})
+			.then(rawData => {
+				const trimmedTrx = rawData.map(trx => {
+					return _.omit(trx, ['client', 'account', ]);
+				});
+				return {
+					currency: acct.currency,
+					name: acct.name,
+					id: acct.id,
+					type: acct.type,
+					created_at: acct.created_at,
+					updated_at: acct.updated_at,
+					trans: trimmedTrx
+				};
+			})
+		}));
+	})
+	.then(accounts => {
+		const currencies = {};
+		accounts.forEach(account => {
+			const data = {
+				exchange: 'coinbase',
+				currency: account.currency
+			};
+			data.trans = account.trans.map(trx => {
+				// convert coinbase tran into common style of trans
+				return trx;
+			});
+			data.trans.sort((x, y) => {
+				return (+x.date) - (+y.date);
+			});
+			currencies[account.currency] = data;
+		});
+		process.exit();
+	})
+	.catch(err => {
+		console.error(err);
+		process.exit();
+	});
+
+/* Example transactions
+{
+    "id": "672b15d8-584c-5888-ab37-d95f412afa0c",
+    "type": "buy",
+    "status": "completed",
+    "amount": {
+      "amount": "1.00000000",
+      "currency": "BTC"
+    },
+    "native_amount": {
+      "amount": "2195.53",
+      "currency": "USD"
+    },
+    "description": null,
+    "created_at": "2017-05-27T19:27:56Z",
+    "updated_at": "2017-06-05T19:28:29Z",
+    "resource": "transaction",
+    "resource_path": "/v2/accounts/163dc9c9-8244-59d2-81c4-707723c3d63f/transactions/672b15d8-584c-5888-ab37-d95f412afa0c",
+    "instant_exchange": false,
+    "buy": {
+      "id": "21d6d148-d011-543d-9d2e-3fff3c554947",
+      "resource": "buy",
+      "resource_path": "/v2/accounts/163dc9c9-8244-59d2-81c4-707723c3d63f/buys/21d6d148-d011-543d-9d2e-3fff3c554947"
+    },
+    "details": {
+      "title": "Bought bitcoin",
+      "subtitle": "using Bank of America - Bank ********7645",
+      "payment_method_name": "Bank of America - Bank ********7645"
+    }
+  },
+  {
+    "id": "ce2fccfa-bf42-51e7-a1bd-24128254a73f",
+    "type": "sell",
+    "status": "completed",
+    "amount": {
+      "amount": "-2.24671000",
+      "currency": "BTC"
+    },
+    "native_amount": {
+      "amount": "-5000.51",
+      "currency": "USD"
+    },
+    "description": null,
+    "created_at": "2017-05-23T23:21:33Z",
+    "updated_at": "2017-05-23T23:21:33Z",
+    "resource": "transaction",
+    "resource_path": "/v2/accounts/163dc9c9-8244-59d2-81c4-707723c3d63f/transactions/ce2fccfa-bf42-51e7-a1bd-24128254a73f",
+    "instant_exchange": false,
+    "sell": {
+      "id": "6efc0b47-627f-5b27-9bce-99e351c6170c",
+      "resource": "sell",
+      "resource_path": "/v2/accounts/163dc9c9-8244-59d2-81c4-707723c3d63f/sells/6efc0b47-627f-5b27-9bce-99e351c6170c"
+    },
+    "details": {
+      "title": "Sold bitcoin",
+      "subtitle": "using Bank of America - Bank ********7645",
+      "payment_method_name": "Bank of America - Bank ********7645"
+    }
+  },
+  {
+    "id": "fb563682-fe3f-55d0-a511-ae19690f9dee",
+    "type": "send",
+    "status": "completed",
+    "amount": {
+      "amount": "2.24671000",
+      "currency": "BTC"
+    },
+    "native_amount": {
+      "amount": "5016.85",
+      "currency": "USD"
+    },
+    "description": null,
+    "created_at": "2017-05-23T17:09:34Z",
+    "updated_at": "2017-05-23T17:14:16Z",
+    "resource": "transaction",
+    "resource_path": "/v2/accounts/163dc9c9-8244-59d2-81c4-707723c3d63f/transactions/fb563682-fe3f-55d0-a511-ae19690f9dee",
+    "instant_exchange": false,
+    "network": {
+      "status": "confirmed",
+      "hash": "54241450b1d1ef6c9d1b0228579dab53d129868b1dce07288d84d31a31ed306d"
+    },
+    "from": {
+      "resource": "bitcoin_network"
+    },
+    "details": {
+      "title": "Received bitcoin",
+      "subtitle": "from Bitcoin address"
+    }
+  },
+*/

--- a/lib/exchanges/coinbase.js
+++ b/lib/exchanges/coinbase.js
@@ -13,6 +13,40 @@ const keys = require('../../api-key')['coinbase'];
 
 const client = new CoinbaseClient({ apiKey: keys.api_key, apiSecret: keys.api_secret });
 
+const getWithdrawalInfo = (trx) => {
+	if (trx.type === 'exchange_deposit') {
+		return {
+			name: 'gdax'
+		};
+	}
+	if (trx.type === 'fiat_withdrawal') {
+		return {
+			name: _.get(trx, 'details.payment_method_name')
+		};
+	}
+	if (trx.type === 'send' && trx.to) {
+		return trx.to;
+	}
+	return false;
+};
+
+const getDepositInfo = (trx) => {
+	if (trx.type === 'exchange_withdrawal') {
+		return {
+			name: 'gdax'
+		};
+	}
+	if (trx.type === 'fiat_deposit') {
+		return {
+			name: _.get(trx, 'details.payment_method_name')
+		};
+	}
+	if (trx.type === 'send' && trx.from) {
+		return trx.from;
+	}
+	return false;
+};
+
 const paginateLoop = (results, request, pagination) => {
 	if (pagination && pagination.next_uri) {
 		return paginate(results, request, pagination);
@@ -425,22 +459,75 @@ module.exports = {
 									date: dt.toDate(),
 									ts: +dt,
 									updated_date: updatedDt.toDate(),
-									updated_ts: +updatedDt,
-									pair: `${account.currency}_${otherCurr}`
+									updated_ts: +updatedDt
 								});
-
-							// convert coinbase tran into common style of trx
-							data.trx.push({
+							let newTrx = {
 								exchange: 'coinbase',
-								type: trx.type,
+								type: '',
 								currency: account.currency,
-								other_currency: otherCurr,
 								date: dt.toDate(),
 								ts: +dt,
 								amount: Math.abs(netAmount),
 								change: netAmount,
-								details: details
-							});
+								fill: details
+							};
+							if (getWithdrawalInfo(trx)) {
+								newTrx.type = 'withdrawal';
+								newTrx.withdrawal_target = getWithdrawalInfo(trx);
+							} else if (getDepositInfo(trx)) {
+								newTrx.type = 'deposit';
+								newTrx.deposit_source = getDepositInfo(trx);
+							} else if (trx.type === 'buy' || trx.type === 'sell') {
+								newTrx.type = trx.type;
+								newTrx.cost = parseNum(_.get(trx, 'native_amount.amount'));
+								newTrx.price = newTrx.cost / newTrx.amount;
+								newTrx.price_currency = otherCurr;
+
+								// If buy or selling diretly from bank, add a deposit/withdrawal for consistancy
+								if (_.get(trx, 'details.payment_method_name') !== 'USD Wallet') {
+									if (trx.type === 'buy') {
+										// For a buy, we'll add in deposit slightly before
+										const fakeDt = moment((+dt) - 1);
+										data.trx.push({
+											psuedo: true,
+											exchange: 'coinbase',
+											type: 'desposit',
+											currency: otherCurr,
+											date: fakeDt.toDate(),
+											ts: +fakeDt,
+											amount: newTrx.cost,
+											change: newTrx.cost,
+											fill: details,
+											deposit_source: {
+												name: 'Bank (pseudo-deposit)'
+											}
+										});
+									} else {
+										data.trx.push(newTrx);
+										// For a sell, we'll add a withdrawal slighty after
+										const fakeDt = moment((+dt) + 1);
+										newTrx = {
+											pseudo: true,
+											exchange: 'coinbase',
+											type: 'withdrawal',
+											currency: otherCurr,
+											date: fakeDt.toDate(),
+											ts: +fakeDt,
+											amount: newTrx.cost,
+											change: 0 - newTrx.cost,
+											fill: details,
+											withdrawal_target: {
+												name: 'Bank (psuedo-withdrawal)'
+											}
+										};
+									}
+								}
+							} else {
+								console.error(`Invalid trx type ${trx.type}`);
+								return;
+							}
+
+							data.trx.push(newTrx);
 						}
 					});
 					data.trx.sort((x, y) => {

--- a/lib/exchanges/coinbase.js
+++ b/lib/exchanges/coinbase.js
@@ -42,7 +42,7 @@ module.exports = {
 	"USD": {
 	    "exchange": "coinbase",
 	    "currency": "USD",
-	    "trans": [
+	    "trx": [
 	      {
 	        "exchange": "coinbase",
 	        "type": "sell",
@@ -170,7 +170,7 @@ module.exports = {
 	"ETH": {
 	    "exchange": "coinbase",
 	    "currency": "ETH",
-	    "trans": [
+	    "trx": [
 	        "exchange": "coinbase",
 	        "type": "exchange_deposit",
 	        "currency": "ETH",
@@ -400,7 +400,7 @@ module.exports = {
 							type: acct.type,
 							created_at: acct.created_at,
 							updated_at: acct.updated_at,
-							trans: trimmedTrx
+							trx: trimmedTrx
 						};
 					})
 				}));
@@ -411,9 +411,9 @@ module.exports = {
 					const data = {
 						exchange: 'coinbase',
 						currency: account.currency,
-						trans: []
+						trx: []
 					};
-					account.trans.forEach(trx => {
+					account.trx.forEach(trx => {
 						if (trx.status === 'completed') {
 							const dt = moment(trx['created_at']);
 							const otherCurr = _.get(trx, 'native_amount.currency');
@@ -429,8 +429,8 @@ module.exports = {
 									pair: `${account.currency}_${otherCurr}`
 								});
 
-							// convert coinbase tran into common style of trans
-							data.trans.push({
+							// convert coinbase tran into common style of trx
+							data.trx.push({
 								exchange: 'coinbase',
 								type: trx.type,
 								currency: account.currency,
@@ -443,7 +443,7 @@ module.exports = {
 							});
 						}
 					});
-					data.trans.sort((x, y) => {
+					data.trx.sort((x, y) => {
 						return (+x.date) - (+y.date);
 					});
 					currencies[account.currency] = data;

--- a/lib/exchanges/coinbase.js
+++ b/lib/exchanges/coinbase.js
@@ -37,138 +37,418 @@ const paginate = (results, request, pagination) => {
 	})
 };
 
-return client.getAccountsAsync({})
-	.then(accts => {
-		return Promise.all(accts.map(acct => {
-			return paginateLoop([], paginationInfo => {
-				return acct.getTransactionsAsync(paginationInfo);
+module.exports = {
+	/* Sample output
+	"USD": {
+	    "exchange": "coinbase",
+	    "currency": "USD",
+	    "trans": [
+	      {
+	        "exchange": "coinbase",
+	        "type": "sell",
+	        "currency": "USD",
+	        "other_currency": "USD",
+	        "date": "2017-02-27T22:29:09.000Z",
+	        "ts": 1488234549000,
+	        "amount": 810.21,
+	        "change": 810.21,
+	        "details": {
+	          "id": "0a0932b1-d2b7-574c-ba0d-34b3603131c4",
+	          "type": "sell",
+	          "amount": {
+	            "amount": "810.21",
+	            "currency": "USD"
+	          },
+	          "native_amount": {
+	            "amount": "810.21",
+	            "currency": "USD"
+	          },
+	          "description": null,
+	          "resource": "transaction",
+	          "resource_path": "/v2/accounts/befbdbdd-1d43-5a6c-8241-f0c04e420680/transactions/0a0932b1-d2b7-574c-ba0d-34b3603131c4",
+	          "instant_exchange": false,
+	          "sell": {
+	            "id": "235edf70-5af2-5b45-b536-7b433f5ae962",
+	            "resource": "sell",
+	            "resource_path": "/v2/accounts/00c7033e-81dd-5953-b544-dbc74d7ee1ad/sells/235edf70-5af2-5b45-b536-7b433f5ae962"
+	          },
+	          "details": {
+	            "title": "Sold ethereum",
+	            "subtitle": "using USD Wallet",
+	            "payment_method_name": "USD Wallet"
+	          },
+	          "date": "2017-02-27T22:29:09.000Z",
+	          "ts": 1488234549000,
+	          "updated_date": "2017-02-27T22:29:10.000Z",
+	          "updated_ts": 1488234550000,
+	          "pair": "USD_USD"
+	        }
+	      },
+	      {
+	        "exchange": "coinbase",
+	        "type": "buy",
+	        "currency": "USD",
+	        "other_currency": "USD",
+	        "date": "2017-02-28T18:02:31.000Z",
+	        "ts": 1488304951000,
+	        "amount": 810.21,
+	        "change": -810.21,
+	        "details": {
+	          "id": "d5155410-809d-5f65-a6d1-7deca0b8e8e9",
+	          "type": "buy",
+	          "amount": {
+	            "amount": "-810.21",
+	            "currency": "USD"
+	          },
+	          "native_amount": {
+	            "amount": "-810.21",
+	            "currency": "USD"
+	          },
+	          "description": null,
+	          "resource": "transaction",
+	          "resource_path": "/v2/accounts/befbdbdd-1d43-5a6c-8241-f0c04e420680/transactions/d5155410-809d-5f65-a6d1-7deca0b8e8e9",
+	          "instant_exchange": false,
+	          "buy": {
+	            "id": "91a597a7-0791-5425-ae40-6611ccd570d2",
+	            "resource": "buy",
+	            "resource_path": "/v2/accounts/163dc9c9-8244-59d2-81c4-707723c3d63f/buys/91a597a7-0791-5425-ae40-6611ccd570d2"
+	          },
+	          "details": {
+	            "title": "Bought bitcoin",
+	            "subtitle": "using USD Wallet",
+	            "payment_method_name": "USD Wallet"
+	          },
+	          "date": "2017-02-28T18:02:31.000Z",
+	          "ts": 1488304951000,
+	          "updated_date": "2017-02-28T18:02:31.000Z",
+	          "updated_ts": 1488304951000,
+	          "pair": "USD_USD"
+	        }
+	      },
+	      {
+	        "exchange": "coinbase",
+	        "type": "fiat_withdrawal",
+	        "currency": "USD",
+	        "other_currency": "USD",
+	        "date": "2017-05-27T20:21:55.000Z",
+	        "ts": 1495916515000,
+	        "amount": 2200,
+	        "change": -2200,
+	        "details": {
+	          "id": "81cf557d-f2f1-5966-bba4-4d811012d889",
+	          "type": "fiat_withdrawal",
+	          "amount": {
+	            "amount": "-2200.00",
+	            "currency": "USD"
+	          },
+	          "native_amount": {
+	            "amount": "-2200.00",
+	            "currency": "USD"
+	          },
+	          "description": null,
+	          "resource": "transaction",
+	          "resource_path": "/v2/accounts/befbdbdd-1d43-5a6c-8241-f0c04e420680/transactions/81cf557d-f2f1-5966-bba4-4d811012d889",
+	          "instant_exchange": false,
+	          "fiat_withdrawal": {
+	            "id": "62708c91-bfb0-58c5-b1a7-5bb86cf4a176",
+	            "resource": "fiat_withdrawal",
+	            "resource_path": "/v2/accounts/befbdbdd-1d43-5a6c-8241-f0c04e420680/withdrawals/62708c91-bfb0-58c5-b1a7-5bb86cf4a176"
+	          },
+	          "details": {
+	            "title": "Withdrew funds",
+	            "subtitle": "to Bank of America - Bank ********7645",
+	            "payment_method_name": "Bank of America - Bank ********7645"
+	          },
+	          "date": "2017-05-27T20:21:55.000Z",
+	          "ts": 1495916515000,
+	          "updated_date": "2017-05-27T20:21:55.000Z",
+	          "updated_ts": 1495916515000,
+	          "pair": "USD_USD"
+	        }
+	      }]
+	},
+	"ETH": {
+	    "exchange": "coinbase",
+	    "currency": "ETH",
+	    "trans": [
+	        "exchange": "coinbase",
+	        "type": "exchange_deposit",
+	        "currency": "ETH",
+	        "other_currency": "USD",
+	        "date": "2017-05-27T03:09:06.000Z",
+	        "ts": 1495854546000,
+	        "amount": 51.99,
+	        "change": -51.99,
+	        "details": {
+	          "id": "e1dab222-1850-56f1-ad08-e420fc7dfdd2",
+	          "type": "exchange_deposit",
+	          "amount": {
+	            "amount": "-51.99000000",
+	            "currency": "ETH"
+	          },
+	          "native_amount": {
+	            "amount": "-8546.11",
+	            "currency": "USD"
+	          },
+	          "description": null,
+	          "resource": "transaction",
+	          "resource_path": "/v2/accounts/00c7033e-81dd-5953-b544-dbc74d7ee1ad/transactions/e1dab222-1850-56f1-ad08-e420fc7dfdd2",
+	          "instant_exchange": false,
+	          "details": {
+	            "title": "Transferred ethereum",
+	            "subtitle": "to GDAX"
+	          },
+	          "date": "2017-05-27T03:09:06.000Z",
+	          "ts": 1495854546000,
+	          "updated_date": "2017-05-27T03:09:06.000Z",
+	          "updated_ts": 1495854546000,
+	          "pair": "ETH_USD"
+	        }
+	      },
+	      {
+	        "exchange": "coinbase",
+	        "type": "sell",
+	        "currency": "ETH",
+	        "other_currency": "USD",
+	        "date": "2017-05-27T09:55:56.000Z",
+	        "ts": 1495878956000,
+	        "amount": 2.63967238,
+	        "change": -2.63967238,
+	        "details": {
+	          "id": "dc58fb02-9c00-51c5-bd0a-80494d0d7ee9",
+	          "type": "sell",
+	          "amount": {
+	            "amount": "-2.63967238",
+	            "currency": "ETH"
+	          },
+	          "native_amount": {
+	            "amount": "-336.35",
+	            "currency": "USD"
+	          },
+	          "description": null,
+	          "resource": "transaction",
+	          "resource_path": "/v2/accounts/00c7033e-81dd-5953-b544-dbc74d7ee1ad/transactions/dc58fb02-9c00-51c5-bd0a-80494d0d7ee9",
+	          "instant_exchange": false,
+	          "sell": {
+	            "id": "4254e641-245f-5e3e-bd19-ed7804811325",
+	            "resource": "sell",
+	            "resource_path": "/v2/accounts/00c7033e-81dd-5953-b544-dbc74d7ee1ad/sells/4254e641-245f-5e3e-bd19-ed7804811325"
+	          },
+	          "details": {
+	            "title": "Sold ethereum",
+	            "subtitle": "using USD Wallet",
+	            "payment_method_name": "USD Wallet"
+	          },
+	          "date": "2017-05-27T09:55:56.000Z",
+	          "ts": 1495878956000,
+	          "updated_date": "2017-05-27T09:55:56.000Z",
+	          "updated_ts": 1495878956000,
+	          "pair": "ETH_USD"
+	        }
+	      },
+	      {
+	        "exchange": "coinbase",
+	        "type": "exchange_withdrawal",
+	        "currency": "ETH",
+	        "other_currency": "USD",
+	        "date": "2017-05-27T17:48:58.000Z",
+	        "ts": 1495907338000,
+	        "amount": 61,
+	        "change": 61,
+	        "details": {
+	          "id": "369b3732-0943-5789-a577-6ad7026c1ac7",
+	          "type": "exchange_withdrawal",
+	          "amount": {
+	            "amount": "61.00000000",
+	            "currency": "ETH"
+	          },
+	          "native_amount": {
+	            "amount": "9871.63",
+	            "currency": "USD"
+	          },
+	          "description": null,
+	          "resource": "transaction",
+	          "resource_path": "/v2/accounts/00c7033e-81dd-5953-b544-dbc74d7ee1ad/transactions/369b3732-0943-5789-a577-6ad7026c1ac7",
+	          "instant_exchange": false,
+	          "details": {
+	            "title": "Transferred ethereum",
+	            "subtitle": "from GDAX"
+	          },
+	          "date": "2017-05-27T17:48:58.000Z",
+	          "ts": 1495907338000,
+	          "updated_date": "2017-05-27T17:48:58.000Z",
+	          "updated_ts": 1495907338000,
+	          "pair": "ETH_USD"
+	        }
+	      },
+	      {
+	        "exchange": "coinbase",
+	        "type": "send",
+	        "currency": "ETH",
+	        "other_currency": "USD",
+	        "date": "2017-05-27T17:48:59.000Z",
+	        "ts": 1495907339000,
+	        "amount": 61,
+	        "change": -61,
+	        "details": {
+	          "id": "3a54f509-cb64-5531-8ebf-b1c695ddff82",
+	          "type": "send",
+	          "amount": {
+	            "amount": "-61.00000000",
+	            "currency": "ETH"
+	          },
+	          "native_amount": {
+	            "amount": "-9871.63",
+	            "currency": "USD"
+	          },
+	          "description": null,
+	          "resource": "transaction",
+	          "resource_path": "/v2/accounts/00c7033e-81dd-5953-b544-dbc74d7ee1ad/transactions/3a54f509-cb64-5531-8ebf-b1c695ddff82",
+	          "instant_exchange": false,
+	          "network": {
+	            "status": "confirmed",
+	            "hash": "7c0a9cc9a55a8d6484a4d83623493bd3bd9fccb312f6ede759009a88fe8e37a0",
+	            "transaction_fee": {
+	              "amount": "0.00000000",
+	              "currency": "ETH"
+	            },
+	            "transaction_amount": {
+	              "amount": "61.00000000",
+	              "currency": "ETH"
+	            },
+	            "confirmations": 96881
+	          },
+	          "to": {
+	            "resource": "ethereum_address",
+	            "address": "0x9d2c7d65e7dd4b8aaa1057cfe54057f453ddf43a"
+	          },
+	          "idem": "41d6911e-ba6e-4a44-8b9b-bdb922b90687",
+	          "application": {
+	            "id": "98563804-126a-5612-a8c3-80db56038519",
+	            "resource": "application",
+	            "resource_path": "/v2/applications/98563804-126a-5612-a8c3-80db56038519"
+	          },
+	          "details": {
+	            "title": "Sent ethereum",
+	            "subtitle": "to Ethereum address"
+	          },
+	          "date": "2017-05-27T17:48:59.000Z",
+	          "ts": 1495907339000,
+	          "updated_date": "2017-05-27T17:50:14.000Z",
+	          "updated_ts": 1495907414000,
+	          "pair": "ETH_USD"
+	        }
+	      },
+	      {
+	        "exchange": "coinbase",
+	        "type": "buy",
+	        "currency": "ETH",
+	        "other_currency": "USD",
+	        "date": "2017-05-27T18:03:49.000Z",
+	        "ts": 1495908229000,
+	        "amount": 30.51632327,
+	        "change": 30.51632327,
+	        "details": {
+	          "id": "a51315ac-720b-5c45-9f05-c6a5e5ff96b9",
+	          "type": "buy",
+	          "amount": {
+	            "amount": "30.51632327",
+	            "currency": "ETH"
+	          },
+	          "native_amount": {
+	            "amount": "5074.50",
+	            "currency": "USD"
+	          },
+	          "description": null,
+	          "resource": "transaction",
+	          "resource_path": "/v2/accounts/00c7033e-81dd-5953-b544-dbc74d7ee1ad/transactions/a51315ac-720b-5c45-9f05-c6a5e5ff96b9",
+	          "instant_exchange": false,
+	          "buy": {
+	            "id": "782a8f14-d121-51a5-b2e9-2aeea8365871",
+	            "resource": "buy",
+	            "resource_path": "/v2/accounts/00c7033e-81dd-5953-b544-dbc74d7ee1ad/buys/782a8f14-d121-51a5-b2e9-2aeea8365871"
+	          },
+	          "details": {
+	            "title": "Bought ethereum",
+	            "subtitle": "using USD Wallet",
+	            "payment_method_name": "USD Wallet"
+	          },
+	          "date": "2017-05-27T18:03:49.000Z",
+	          "ts": 1495908229000,
+	          "updated_date": "2017-05-27T18:03:50.000Z",
+	          "updated_ts": 1495908230000,
+	          "pair": "ETH_USD"
+	        }
+	      }]
+	}
+	*/
+	getAllTransactions: () => {
+		return client.getAccountsAsync({})
+			.then(accts => {
+				return Promise.all(accts.map(acct => {
+					return paginateLoop([], paginationInfo => {
+						return acct.getTransactionsAsync(paginationInfo);
+					})
+					.then(rawData => {
+						const trimmedTrx = rawData.map(trx => {
+							return _.omit(trx, ['client', 'account']);
+						});
+						return {
+							currency: acct.currency,
+							name: acct.name,
+							id: acct.id,
+							type: acct.type,
+							created_at: acct.created_at,
+							updated_at: acct.updated_at,
+							trans: trimmedTrx
+						};
+					})
+				}));
 			})
-			.then(rawData => {
-				const trimmedTrx = rawData.map(trx => {
-					return _.omit(trx, ['client', 'account', ]);
-				});
-				return {
-					currency: acct.currency,
-					name: acct.name,
-					id: acct.id,
-					type: acct.type,
-					created_at: acct.created_at,
-					updated_at: acct.updated_at,
-					trans: trimmedTrx
-				};
-			})
-		}));
-	})
-	.then(accounts => {
-		const currencies = {};
-		accounts.forEach(account => {
-			const data = {
-				exchange: 'coinbase',
-				currency: account.currency
-			};
-			data.trans = account.trans.map(trx => {
-				// convert coinbase tran into common style of trans
-				return trx;
-			});
-			data.trans.sort((x, y) => {
-				return (+x.date) - (+y.date);
-			});
-			currencies[account.currency] = data;
-		});
-		process.exit();
-	})
-	.catch(err => {
-		console.error(err);
-		process.exit();
-	});
+			.then(accounts => {
+				const currencies = {};
+				accounts.forEach(account => {
+					const data = {
+						exchange: 'coinbase',
+						currency: account.currency,
+						trans: []
+					};
+					account.trans.forEach(trx => {
+						if (trx.status === 'completed') {
+							const dt = moment(trx['created_at']);
+							const otherCurr = _.get(trx, 'native_amount.currency');
+							const updatedDt = moment(trx['updated_at']);
+							const netAmount = parseNum(_.get(trx, 'amount.amount'));
+							const details = _.merge({},
+								_.omit(trx, ['status', 'created_at', 'updated_at']),
+								{
+									date: dt.toDate(),
+									ts: +dt,
+									updated_date: updatedDt.toDate(),
+									updated_ts: +updatedDt,
+									pair: `${account.currency}_${otherCurr}`
+								});
 
-/* Example transactions
-{
-    "id": "672b15d8-584c-5888-ab37-d95f412afa0c",
-    "type": "buy",
-    "status": "completed",
-    "amount": {
-      "amount": "1.00000000",
-      "currency": "BTC"
-    },
-    "native_amount": {
-      "amount": "2195.53",
-      "currency": "USD"
-    },
-    "description": null,
-    "created_at": "2017-05-27T19:27:56Z",
-    "updated_at": "2017-06-05T19:28:29Z",
-    "resource": "transaction",
-    "resource_path": "/v2/accounts/163dc9c9-8244-59d2-81c4-707723c3d63f/transactions/672b15d8-584c-5888-ab37-d95f412afa0c",
-    "instant_exchange": false,
-    "buy": {
-      "id": "21d6d148-d011-543d-9d2e-3fff3c554947",
-      "resource": "buy",
-      "resource_path": "/v2/accounts/163dc9c9-8244-59d2-81c4-707723c3d63f/buys/21d6d148-d011-543d-9d2e-3fff3c554947"
-    },
-    "details": {
-      "title": "Bought bitcoin",
-      "subtitle": "using Bank of America - Bank ********7645",
-      "payment_method_name": "Bank of America - Bank ********7645"
-    }
-  },
-  {
-    "id": "ce2fccfa-bf42-51e7-a1bd-24128254a73f",
-    "type": "sell",
-    "status": "completed",
-    "amount": {
-      "amount": "-2.24671000",
-      "currency": "BTC"
-    },
-    "native_amount": {
-      "amount": "-5000.51",
-      "currency": "USD"
-    },
-    "description": null,
-    "created_at": "2017-05-23T23:21:33Z",
-    "updated_at": "2017-05-23T23:21:33Z",
-    "resource": "transaction",
-    "resource_path": "/v2/accounts/163dc9c9-8244-59d2-81c4-707723c3d63f/transactions/ce2fccfa-bf42-51e7-a1bd-24128254a73f",
-    "instant_exchange": false,
-    "sell": {
-      "id": "6efc0b47-627f-5b27-9bce-99e351c6170c",
-      "resource": "sell",
-      "resource_path": "/v2/accounts/163dc9c9-8244-59d2-81c4-707723c3d63f/sells/6efc0b47-627f-5b27-9bce-99e351c6170c"
-    },
-    "details": {
-      "title": "Sold bitcoin",
-      "subtitle": "using Bank of America - Bank ********7645",
-      "payment_method_name": "Bank of America - Bank ********7645"
-    }
-  },
-  {
-    "id": "fb563682-fe3f-55d0-a511-ae19690f9dee",
-    "type": "send",
-    "status": "completed",
-    "amount": {
-      "amount": "2.24671000",
-      "currency": "BTC"
-    },
-    "native_amount": {
-      "amount": "5016.85",
-      "currency": "USD"
-    },
-    "description": null,
-    "created_at": "2017-05-23T17:09:34Z",
-    "updated_at": "2017-05-23T17:14:16Z",
-    "resource": "transaction",
-    "resource_path": "/v2/accounts/163dc9c9-8244-59d2-81c4-707723c3d63f/transactions/fb563682-fe3f-55d0-a511-ae19690f9dee",
-    "instant_exchange": false,
-    "network": {
-      "status": "confirmed",
-      "hash": "54241450b1d1ef6c9d1b0228579dab53d129868b1dce07288d84d31a31ed306d"
-    },
-    "from": {
-      "resource": "bitcoin_network"
-    },
-    "details": {
-      "title": "Received bitcoin",
-      "subtitle": "from Bitcoin address"
-    }
-  },
-*/
+							// convert coinbase tran into common style of trans
+							data.trans.push({
+								exchange: 'coinbase',
+								type: trx.type,
+								currency: account.currency,
+								other_currency: otherCurr,
+								date: dt.toDate(),
+								ts: +dt,
+								amount: Math.abs(netAmount),
+								change: netAmount,
+								details: details
+							});
+						}
+					});
+					data.trans.sort((x, y) => {
+						return (+x.date) - (+y.date);
+					});
+					currencies[account.currency] = data;
+				});
+				return currencies;
+			});
+	}
+}

--- a/lib/exchanges/coinbase.js
+++ b/lib/exchanges/coinbase.js
@@ -471,27 +471,36 @@ module.exports = {
 								change: netAmount,
 								fill: details
 							};
-							if (getWithdrawalInfo(trx)) {
+							let wdTgt = getWithdrawalInfo(trx);
+							let dpTgt = (wdTgt) ? false : getDepositInfo(trx);
+							if (wdTgt) {
 								newTrx.type = 'withdrawal';
-								newTrx.withdrawal_target = getWithdrawalInfo(trx);
-							} else if (getDepositInfo(trx)) {
+								newTrx.withdrawal_target = wdTgt;
+							} else if (dpTgt) {
 								newTrx.type = 'deposit';
-								newTrx.deposit_source = getDepositInfo(trx);
+								newTrx.deposit_source = dpTgt;
 							} else if (trx.type === 'buy' || trx.type === 'sell') {
+								const payName = _.get(trx, 'details.payment_method_name');
+								// Buying and selling with USD Wallet creates duplicate transaction
+								// in USD account history...just ignore this one
+								if (newTrx.currency === 'USD' && payName === 'USD Wallet') {
+									return;
+								}
+
 								newTrx.type = trx.type;
 								newTrx.cost = parseNum(_.get(trx, 'native_amount.amount'));
 								newTrx.price = newTrx.cost / newTrx.amount;
 								newTrx.price_currency = otherCurr;
 
 								// If buy or selling diretly from bank, add a deposit/withdrawal for consistancy
-								if (_.get(trx, 'details.payment_method_name') !== 'USD Wallet') {
+								if (payName !== 'USD Wallet') {
 									if (trx.type === 'buy') {
 										// For a buy, we'll add in deposit slightly before
 										const fakeDt = moment((+dt) - 1);
 										data.trx.push({
-											psuedo: true,
+											pseudo: true,
 											exchange: 'coinbase',
-											type: 'desposit',
+											type: 'deposit',
 											currency: otherCurr,
 											date: fakeDt.toDate(),
 											ts: +fakeDt,
@@ -517,7 +526,7 @@ module.exports = {
 											change: 0 - newTrx.cost,
 											fill: details,
 											withdrawal_target: {
-												name: 'Bank (psuedo-withdrawal)'
+												name: 'Bank (pseudo-withdrawal)'
 											}
 										};
 									}

--- a/lib/exchanges/cryptopia-request.js
+++ b/lib/exchanges/cryptopia-request.js
@@ -1,0 +1,99 @@
+const moment = require('moment');
+const rp = require('request-promise');
+const crypto = require('crypto');
+
+class Cryptopia {
+	constructor(api_key, api_secret) {
+		this.api_key = api_key;
+		this.api_secret = api_secret;
+		this.baseUrl = 'https://www.cryptopia.co.nz/Api';
+		this.nonceCache = [];
+
+		this.request = rp.defaults({
+			agent: false,
+			headers: {
+				"User-Agent": "Mozilla/4.0 (compatible; SIGBOT Cryptopia API)",
+				"Content-Type": "application/json; charset=utf-8"
+			},
+			json: true
+		});
+	}
+
+	getNonce() {
+		let nextNonce = moment().unix();
+		while (this.nonceCache.indexOf(nextNonce) !== -1) {
+			nextNonce++;
+		}
+		this.nonceCache.push(nextNonce);
+		return nextNonce;
+	}
+
+	// https://www.cryptopia.co.nz/Forum/Thread/262
+	getAuthorizationHeader(params, url) {
+		const paramStr = JSON.stringify(params);
+		const encodedURL = encodeURIComponent(url).toLowerCase();
+		const nonce = this.getNonce();
+
+		const reqHashB64 = crypto.createHash('md5').update(paramStr).digest().toString('base64');
+		const sig = `${this.api_key}POST${encodedURL}${nonce}${reqHashB64}`;
+		const hmacSig = crypto.createHmac('sha256', new Buffer(this.api_secret, 'base64')).update(sig).digest().toString('base64');
+
+		return `amx ${this.api_key}:${hmacSig}:${nonce}`;
+	}
+
+	privateRequest(path, params) {
+		const url = `${this.baseUrl}/${path}`;
+		params = params || {};
+
+		return this.request({
+			method: 'POST',
+			url: url,
+			body: params,
+			json: true,
+			headers: {
+				'Authorization': this.getAuthorizationHeader(params, url)
+			}
+		})
+		.then(res => {
+			if (!res['Success']) {
+				console.error(res);
+				throw new Error(res['Error']);
+			}
+			return res['Data'];
+		})
+	}
+
+	getMarkets() {
+		return this.request(`${this.baseUrl}/GetMarkets`);
+	}
+
+	getCurrencies() {
+		return this.request(`${this.baseUrl}/GetCurrencies`);
+	}
+
+	getBalance() {
+		return this.privateRequest('GetBalance', {});
+	}
+
+	getTradeHistory() {
+		return this.privateRequest('GetTradeHistory', {
+			Count: '1000'
+		});
+	}
+
+	getWithdrawals() {
+		return this.privateRequest('GetTransactions', {
+			Type: 'Withdraw',
+			Count: '1000'
+		});
+	}
+
+	getDeposits() {
+		return this.privateRequest('GetTransactions', {
+			Type: 'Deposit',
+			Count: '1000'
+		});
+	}
+}
+
+module.exports = Cryptopia;

--- a/lib/exchanges/cryptopia.js
+++ b/lib/exchanges/cryptopia.js
@@ -135,7 +135,7 @@ module.exports = {
 				const pair = trade['Market'].split('/'),
 					currency = pair[0],
 					priceCurrency = pair[1],
-					dt = moment(trade['TimeStamp']),
+					dt = moment.utc(trade['TimeStamp']),
 					type = trade['Type'] === 'Sell' ? 'sell' : 'buy',
 					amount = trade['Amount'];
 				if (type === 'buy' && trade['Type'] !== 'Buy') {
@@ -171,7 +171,7 @@ module.exports = {
 
 			withdrawals.forEach(trade => {
 				if (trade['Status'] === 'Complete') {
-					const dt = moment(trade['Timestamp']),
+					const dt = moment.utc(trade['Timestamp']),
 						currency = trade['Currency'];
 					const trx = {
 						exchange: 'cryptopia',
@@ -198,7 +198,7 @@ module.exports = {
 
 			deposits.forEach(trade => {
 				if (trade['Status'] === 'Confirmed') {
-					const dt = moment(trade['Timestamp']),
+					const dt = moment.utc(trade['Timestamp']),
 						currency = trade['Currency'];
 					const trx = {
 						exchange: 'cryptopia',

--- a/lib/exchanges/cryptopia.js
+++ b/lib/exchanges/cryptopia.js
@@ -1,0 +1,289 @@
+const Promise = require('bluebird');
+const moment = require('moment');
+const _ = require('lodash');
+const parseNum = require('parse-decimal-number');
+
+const Cryptopia = require('./cryptopia-request');
+const keys = require('../../api-key')['cryptopia'];
+
+const cryptopia = new Cryptopia(keys.api_key, keys.api_secret);
+
+module.exports = {
+
+	/* Sample Transactions
+	"CLAM": {
+		"exchange": "cryptopia",
+		"currency": "CLAM",
+		"trx": [
+		  {
+		    "exchange": "cryptopia",
+		    "type": "buy",
+		    "currency": "CLAM",
+		    "date": "2017-04-24T07:22:32.084Z",
+		    "ts": 1493018552084,
+		    "amount": 2.23,
+		    "change": 2.23,
+		    "price": 0.00138094,
+		    "price_currency": "BTC",
+		    "fee": 0.00000616,
+		    "fee_currency": "BTC",
+		    "cost": 0.00308566,
+		    "fill": {
+		      "TradeId": 6856314,
+		      "TradePairId": 2529,
+		      "Market": "CLAM/BTC",
+		      "Type": "Buy",
+		      "Rate": 0.00138094,
+		      "Amount": 2.23,
+		      "Total": 0.0030795,
+		      "Fee": 0.00000616,
+		      "TimeStamp": "2017-04-24T03:22:32.0840592"
+		    }
+		  },
+		  {
+		    "exchange": "cryptopia",
+		    "type": "deposit",
+		    "currency": "CLAM",
+		    "date": "2017-06-17T23:03:39.000Z",
+		    "ts": 1497740619000,
+		    "amount": 14.74078133,
+		    "change": 14.74078133,
+		    "fill": {
+		      "Id": 6215042,
+		      "Currency": "CLAM",
+		      "TxId": "96b95bef1d951c517cc744f02a38ab8894fffff81bf4cf67474d40ba9b9953bc",
+		      "Type": "Deposit",
+		      "Amount": 14.74078133,
+		      "Fee": 0,
+		      "Status": "Confirmed",
+		      "Confirmations": 27,
+		      "Timestamp": "2017-06-17T19:03:39",
+		      "Address": null
+		    }
+		  },
+		  {
+		    "exchange": "cryptopia",
+		    "type": "withdrawal",
+		    "currency": "CLAM",
+		    "date": "2017-06-18T19:58:55.438Z",
+		    "ts": 1497815935438,
+		    "amount": 16.97078133,
+		    "change": -16.97078133,
+		    "fee": 0,
+		    "real_amount": 16.97078133,
+		    "fill": {
+		      "Id": 418489,
+		      "Currency": "CLAM",
+		      "TxId": "fdae06302c7839915929ae482f812ac669dbb10613029d706aac7d4dcec922fd",
+		      "Type": "Withdraw",
+		      "Amount": 16.97078133,
+		      "Fee": 0,
+		      "Status": "Complete",
+		      "Confirmations": 69,
+		      "Timestamp": "2017-06-18T15:58:55.4389796",
+		      "Address": "x8VpqDgQJWxGY1sYYNNb7cYi7of2vrxoSS"
+		    }
+		  }
+		]
+	},
+	"LTC": {
+		"exchange": "cryptopia",
+		"currency": "LTC",
+		"trx": [
+		  {
+		    "exchange": "cryptopia",
+		    "type": "sell",
+		    "currency": "LTC",
+		    "date": "2017-06-17T11:09:33.037Z",
+		    "ts": 1497697773037,
+		    "amount": 1.76291723,
+		    "change": -1.76291723,
+		    "price": 0.01553,
+		    "price_currency": "BTC",
+		    "fee": 0.00005476,
+		    "fee_currency": "BTC",
+		    "cost": 0.027323339999999998,
+		    "fill": {
+		      "TradeId": 10927932,
+		      "TradePairId": 101,
+		      "Market": "LTC/BTC",
+		      "Type": "Sell",
+		      "Rate": 0.01553,
+		      "Amount": 1.76291723,
+		      "Total": 0.0273781,
+		      "Fee": 0.00005476,
+		      "TimeStamp": "2017-06-17T07:09:33.0372594"
+		    }
+		  }
+		]
+	},
+	*/
+	getAllTransactions: () => {
+		const currencies = {};
+
+		return Promise.all([
+			cryptopia.getTradeHistory(),
+			cryptopia.getWithdrawals(),
+			cryptopia.getDeposits()
+		])
+		.then(res => {
+			const trades = res[0],
+				withdrawals = res[1],
+				deposits = res[2];
+
+			trades.forEach(trade => {
+				const pair = trade['Market'].split('/'),
+					currency = pair[0],
+					priceCurrency = pair[1],
+					dt = moment(trade['TimeStamp']),
+					type = trade['Type'] === 'Sell' ? 'sell' : 'buy',
+					amount = trade['Amount'];
+				if (type === 'buy' && trade['Type'] !== 'Buy') {
+					console.error(`Invalid Trade Type ${trade['Type']}`);
+					console.error(trade);
+					return;
+				}
+				const cost = (type === 'sell') ? trade['Total'] - trade['Fee'] : trade['Total'] + trade['Fee'];
+				const trx = {
+					exchange: 'cryptopia',
+					type: type,
+					currency: currency,
+					date: dt.toDate(),
+					ts: +dt,
+					amount: amount,
+					change: type === 'sell' ? (0 - amount) : amount,
+					price: trade['Rate'],
+					price_currency: priceCurrency,
+					fee: trade['Fee'],
+					fee_currency: priceCurrency,
+					cost: cost,
+					fill: trade
+				}
+				if (!currencies[currency]) {
+					currencies[currency] = {
+						exchange: 'cryptopia',
+						currency: currency,
+						trx: []
+					};
+				}
+				currencies[currency].trx.push(trx);
+			});
+
+			withdrawals.forEach(trade => {
+				if (trade['Status'] === 'Complete') {
+					const dt = moment(trade['Timestamp']),
+						currency = trade['Currency'];
+					const trx = {
+						exchange: 'cryptopia',
+						type: 'withdrawal',
+						currency: currency,
+						date: dt.toDate(),
+						ts: +dt,
+						amount: trade['Amount'],
+						change: 0 - trade['Amount'],
+						fee: trade['Fee'],
+						real_amount: trade['Amount'] - trade['Fee'],
+						fill: trade
+					};
+					if (!currencies[currency]) {
+						currencies[currency] = {
+							exchange: 'cryptopia',
+							currency: currency,
+							trx: []
+						};
+					}
+					currencies[currency].trx.push(trx);
+				}
+			});
+
+			deposits.forEach(trade => {
+				if (trade['Status'] === 'Confirmed') {
+					const dt = moment(trade['Timestamp']),
+						currency = trade['Currency'];
+					const trx = {
+						exchange: 'cryptopia',
+						type: 'deposit',
+						currency: currency,
+						date: dt.toDate(),
+						ts: +dt,
+						amount: trade['Amount'],
+						change: trade['Amount'],
+						fill: trade
+					};
+					if (!currencies[currency]) {
+						currencies[currency] = {
+							exchange: 'cryptopia',
+							currency: currency,
+							trx: []
+						};
+					}
+					currencies[currency].trx.push(trx);
+				}
+			});
+
+			Object.keys(currencies).forEach(currency => {
+				const data = currencies[currency];
+				data.trx.sort((x, y) => {
+					return (+x.date) - (+y.date);
+				});
+			});
+
+			return currencies;
+		});
+	}
+};
+
+/* Sample Deposit
+{
+  "Id": 6215042,
+  "Currency": "CLAM",
+  "TxId": "96b95bef1d951c517cc744f02a38ab8894fffff81bf4cf67474d40ba9b9953bc",
+  "Type": "Deposit",
+  "Amount": 14.74078133,
+  "Fee": 0,
+  "Status": "Confirmed",
+  "Confirmations": 27,
+  "Timestamp": "2017-06-17T19:03:39",
+  "Address": null
+}
+*/
+
+/* Sample Withdrawal
+{
+  "Id": 435365,
+  "Currency": "BTC",
+  "TxId": "3e89179b2a07d27b058a635da77dd76f2356df535d03583b64efc296af056b5d",
+  "Type": "Withdraw",
+  "Amount": 0.09522137,
+  "Fee": 0,
+  "Status": "Complete",
+  "Confirmations": 25,
+  "Timestamp": "2017-06-24T05:03:20.0944498",
+  "Address": "15eJvJn9XGJReCRoGWPJgWP45tGkDetuVz"
+},
+*/
+
+/* Sample Trades
+{
+  "TradeId": 11231652,
+  "TradePairId": 5121,
+  "Market": "XBY/BTC",
+  "Type": "Sell",
+  "Rate": 0.00000801,
+  "Amount": 4955.15065304,
+  "Total": 0.03969076,
+  "Fee": 0.00007938,
+  "TimeStamp": "2017-06-22T07:06:57.5868269"
+},
+{
+  "TradeId": 10928122,
+  "TradePairId": 5121,
+  "Market": "XBY/BTC",
+  "Type": "Buy",
+  "Rate": 0.00001194,
+  "Amount": 8.37520938,
+  "Total": 0.0001,
+  "Fee": 2E-7,
+  "TimeStamp": "2017-06-17T07:13:47.009774"
+},
+*/

--- a/lib/exchanges/gdax.js
+++ b/lib/exchanges/gdax.js
@@ -41,7 +41,7 @@ module.exports = {
 	"ETH": {
 	    "exchange": "gdax",
 	    "currency": "ETH",
-	    "trans": [
+	    "trx": [
 	      {
 	        "exchange": "gdax",
 	        "type": "deposit",
@@ -187,7 +187,7 @@ module.exports = {
 				       trade_id: '4851312',
 				       product_id: 'ETH-USD' } }
 				*/
-				data.trans = accountInfo.history.map(action => {
+				data.trx = accountInfo.history.map(action => {
 					if (action.type === 'transfer') {
 						const transferType = _.get(action, 'details.transfer_type');
 						if (transferTypes.indexOf(transferType) === -1) {
@@ -231,7 +231,7 @@ module.exports = {
 						throw new Error('invalid type on action');
 					}
 				});
-				data.trans.sort((x, y) => {
+				data.trx.sort((x, y) => {
 					return (+x.date) - (+y.date);
 				});
 				currencies[accountInfo.currency] = data;

--- a/lib/exchanges/gdax.js
+++ b/lib/exchanges/gdax.js
@@ -142,6 +142,10 @@ module.exports = {
 					    hold: '0.0000000000000000',
 					    profile_id: '5dc5e714-0405-4cb8-af0d-d7310beb53ed' }
 					*/
+					if (typeof res[1].message === 'string') {
+						console.error(`${res[1]}`);
+						throw new Error(`unabled to retrieve gdax accounts: ${res[1].message}`);
+					}
 					res[1].forEach(account => {
 						accounts[account.currency] = account;
 					});
@@ -198,7 +202,7 @@ module.exports = {
 						const netAmount = parseNum(action['amount']);
 						const tran = {
 							exchange: 'gdax',
-							type: transferType,
+							type: (transferType === 'withdraw') ? 'withdrawal' : transferType,
 							currency: accountInfo.currency,
 							date: dt.toDate(),
 							ts: +dt,

--- a/lib/exchanges/gdax.js
+++ b/lib/exchanges/gdax.js
@@ -230,7 +230,7 @@ module.exports = {
 				});
 				data.trans.sort((x, y) => {
 					return (+x.date) - (+y.date);
-				})
+				});
 				currencies[accountInfo.currency] = data;
 			});
 

--- a/lib/exchanges/gdax.js
+++ b/lib/exchanges/gdax.js
@@ -1,0 +1,257 @@
+const Promise = require('bluebird');
+const moment = require('moment');
+const _ = require('lodash');
+const parseNum = require('parse-decimal-number');
+
+const gdax = require('gdax');
+const AuthenticatedClient = gdax.AuthenticatedClient;
+Promise.promisifyAll(AuthenticatedClient.prototype, { multiArgs: true });
+
+const keys = require('../../api-key')['gdax'];
+
+const authedClient = new AuthenticatedClient(keys.api_key, keys.api_secret, keys.pass_phrase);
+
+const paginateLoop = (results, request, cbAfter) => {
+	if (cbAfter) {
+		return paginate(results, request, { after: cbAfter });
+	} else {
+		return paginate(results, request);
+	}
+};
+
+const paginate = (results, request, query) => {
+	return request(query).then(res => {
+		//console.log(`${res[1].length} paginated results`);
+		if (res[1] && res[1].length) {
+			results = results.concat(res[1]);
+		}
+		if (res[0].headers && res[0].headers['cb-after']) {
+			return paginateLoop(results, request, res[0].headers['cb-after'])
+				.then(allResults => {
+					return allResults;
+				});
+		} else {
+			return Promise.resolve(results);
+		}
+	})
+};
+
+module.exports = {
+	/* Sample output
+	"ETH": {
+	    "exchange": "gdax",
+	    "currency": "ETH",
+	    "trans": [
+	      {
+	        "exchange": "gdax",
+	        "type": "deposit",
+	        "currency": "ETH",
+	        "date": "2017-05-27T03:09:06.707Z",
+	        "ts": 1495854546707,
+	        "amount": 51.99,
+	        "change": 51.99
+	      },
+	      {
+	        "exchange": "gdax",
+	        "type": "sell",
+	        "currency": "ETH",
+	        "date": "2017-05-27T03:32:38.588Z",
+	        "ts": 1495855958588,
+	        "amount": 1.561215,
+	        "change": -1.561215,
+	        "fill": {
+	          "type": "sell",
+	          "amount": 1.561215,
+	          "price": 160.2,
+	          "fee": 0,
+	          "fee_type": "Maker",
+	          "date": "2017-05-27T03:32:38.588Z",
+	          "ts": 1495855958588,
+	          "pair": "ETH_USD",
+	          "order_id": "23be4828-e539-48cb-9a7b-64f1a2dc9dd4",
+	          "trade_id": 4738917
+	        }
+	      },
+	      ...
+	},
+	"LTC": { ... }
+	}
+	*/
+	getAllTransactions: () => {
+		const accounts = {};
+
+		// Build an order collection using all fills
+		const orders = {};
+
+		return paginateLoop([], query => {
+			return query ? authedClient.getFillsAsync(query) : authedClient.getFillsAsync();
+		})
+		.then(allFills => {
+			/* Fills
+			{ created_at: '2017-06-07T07:06:06.975Z',
+			  trade_id: 16387982,
+			  product_id: 'BTC-USD',
+			  order_id: '21a6258c-6981-4e91-b2e5-6b834be8e738',
+			  user_id: '516308ba325d1a0f49000005',
+			  profile_id: '5dc5e714-0405-4cb8-af0d-d7310beb53ed',
+			  liquidity: 'M',
+			  price: '2806.00000000',
+			  size: '0.71891175',
+			  fee: '0.0000000000000000',
+			  side: 'sell',
+			  settled: true }
+			*/
+			const liquidities = ['M', 'T'];
+			allFills.forEach(fill => {
+				if (!orders[fill['order_id']]) {
+					orders[fill['order_id']] = {};
+				}
+				if (orders[fill['order_id']][fill['trade_id']]) {
+					throw new Error(`Duplicate Trades ${fill.order_id} + ${fill.trade_id}`);
+				}
+				if (liquidities.indexOf(fill['liquidity']) === -1) {
+					throw new Error(`Invalid liquidity ${fill.liquidity}`);
+				}
+				const dt = moment(fill['created_at']);
+				const pair = fill['product_id'].split('-');
+				orders[fill['order_id']][fill['trade_id']] = {
+					type: fill['side'],
+					amount: parseNum(fill['size']),
+					price: parseNum(fill['price']),
+					fee: parseNum(fill['fee']),
+					fee_type: fill['liquidity'] === 'M' ? 'Maker' : 'Taker',
+					date: dt.toDate(),
+					ts: +dt,
+					pair: `${pair[0]}_${pair[1]}`,
+					order_id: fill['order_id'],
+					trade_id: fill['trade_id']
+				};
+			});
+
+			// Get all accounts and the account history for each one
+			return authedClient.getAccountsAsync()
+				.then(res => {
+					/* Accounts
+					{ id: '3484e356-1502-4cc8-b22b-51692d3d16f3',
+					    currency: 'USD',
+					    balance: '0.0011729622075500',
+					    available: '0.0011729622075500',
+					    hold: '0.0000000000000000',
+					    profile_id: '5dc5e714-0405-4cb8-af0d-d7310beb53ed' }
+					*/
+					res[1].forEach(account => {
+						accounts[account.currency] = account;
+					});
+
+					const accountQueries = Object.keys(accounts).map(currency => {
+						let accountInfo = accounts[currency];
+						return paginateLoop([], query => {
+							return query ? authedClient.getAccountHistoryAsync(accountInfo.id, query) : authedClient.getAccountHistoryAsync(accountInfo.id);
+						})
+						.then(accountHistory => {
+							accountInfo.history = accountHistory;
+							return accountInfo;
+						})
+					});
+
+					return Promise.all(accountQueries);
+				});
+		})
+		.then(accountHistories => {
+			const currencies = {};
+			const transferTypes = ['deposit', 'withdraw'];
+			accountHistories.forEach(accountInfo => {
+				const data = {
+					exchange: 'gdax',
+					currency: accountInfo.currency
+				};
+				/* Account History
+				{ created_at: '2017-05-28T06:23:13.865145Z',
+				    id: 160186377,
+				    amount: '-9.4000000000000000',
+				    balance: '0.0000000000000000',
+				    type: 'transfer',
+				    details:
+				     { transfer_id: 'b61e513b-d004-4ebe-8f60-fed48e7cfa09',
+				       transfer_type: 'withdraw' } },
+				{ created_at: '2017-05-28T06:22:02.794009Z',
+				    id: 160185758,
+				    amount: '9.3742573900000000',
+				    balance: '9.4000000000000000',
+				    type: 'match',
+				    details:
+				     { order_id: '549bebbb-0caf-46db-a5d9-e26969784e22',
+				       trade_id: '4851312',
+				       product_id: 'ETH-USD' } }
+				*/
+				data.trans = accountInfo.history.map(action => {
+					if (action.type === 'transfer') {
+						const transferType = _.get(action, 'details.transfer_type');
+						if (transferTypes.indexOf(transferType) === -1) {
+							console.error(action);
+							throw new Error('invalid "transfer"');
+						}
+						const dt = moment(action['created_at']);
+						const netAmount = parseNum(action['amount']);
+						const tran = {
+							exchange: 'gdax',
+							type: transferType,
+							currency: accountInfo.currency,
+							date: dt.toDate(),
+							ts: +dt,
+							amount: Math.abs(netAmount),
+							change: netAmount
+						};
+						return tran;
+					} else if (action.type === 'match' || action.type === 'fee') {
+						const orderId = _.get(action, 'details.order_id');
+						const tradeId = _.get(action, 'details.trade_id');
+						if (!orderId || !orders[orderId] || !orders[orderId][tradeId]) {
+							console.error(action);
+							throw new Error('invalid "details.order_id + details.trade_id"')
+						}
+						const theFill = orders[orderId][tradeId];
+						const netAmount = parseNum(action['amount']);
+						const tran = {
+							exchange: 'gdax',
+							type: action.type === 'match' ? theFill['type'] : 'fee',
+							currency: accountInfo.currency,
+							date: theFill['date'],
+							ts: theFill['ts'],
+							amount: Math.abs(netAmount),
+							change: netAmount,
+							fill: theFill
+						};
+						return tran;
+					} else {
+						console.error(action);
+						throw new Error('invalid type on action');
+					}
+				});
+				data.trans.sort((x, y) => {
+					return (+x.date) - (+y.date);
+				})
+				currencies[accountInfo.currency] = data;
+			});
+
+			return currencies;
+		});
+	}
+};
+
+/*
+return authedClient.getAccountsAsync()
+	.then(res => {
+		console.log(res[1]);
+		process.exit();
+	})
+*/
+
+/*return paginateLoop([], query => {
+		return query ? authedClient.getFillsAsync(query) : authedClient.getFillsAsync();
+	})
+	.then(allFills => {
+		console.log(`${allFills.length} total fills`);
+		process.exit();
+	});
+*/

--- a/lib/exchanges/gdax.js
+++ b/lib/exchanges/gdax.js
@@ -112,6 +112,9 @@ module.exports = {
 				if (liquidities.indexOf(fill['liquidity']) === -1) {
 					throw new Error(`Invalid liquidity ${fill.liquidity}`);
 				}
+				if (!fill['settled']) {
+					return;
+				}
 				const dt = moment(fill['created_at']);
 				const pair = fill['product_id'].split('-');
 				orders[fill['order_id']][fill['trade_id']] = {

--- a/lib/exchanges/poloniex.js
+++ b/lib/exchanges/poloniex.js
@@ -12,14 +12,15 @@ Promise.promisifyAll(Poloniex.prototype, {
 	}
 });
 
+const poloniex = new Poloniex(keys.api_key, keys.api_secret);
+
+const EARLIEST_DATE = new Date(2017,3,1,0,0,0,0);
+
 module.exports = {
 	getAllTransactions: () => {
-		const dateLimit = new Date(2017,3,1,0,0,0,0);
-		const poloniex = new Poloniex(keys.api_key, keys.api_secret);
-
 		const parameters = {
 			currencyPair: 'all',
-			start: Math.floor(dateLimit.getTime() / 1000),
+			start: Math.floor(EARLIEST_DATE.getTime() / 1000),
 			end: Math.floor(new Date().getTime() / 1000)
 		};
 
@@ -160,6 +161,26 @@ module.exports = {
 				});
 
 				return currencies;
+			});
+	},
+
+	getCoins: () => {
+		return poloniex.returnTickerAsync()
+			.then((data) => {
+				//const quick = [Object.keys(data)[0]];
+				//return Promise.each(quick, (pair) => {
+				return Promise.each(Object.keys(data), (pair) => {
+					if (pair.indexOf('BTC_') !== 0 || blacklist.indexOf(pair) !== -1) {
+						return {};
+					}
+
+					const name = pair.split("_")[1];
+					const data = {
+						pair: pair,
+						name: name,
+						changes: []
+					};
+				});
 			});
 	}
 }

--- a/lib/exchanges/poloniex.js
+++ b/lib/exchanges/poloniex.js
@@ -1,0 +1,214 @@
+const Promise = require('bluebird');
+const moment = require('moment');
+const _ = require('lodash');
+const parseNum = require('parse-decimal-number');
+
+const Poloniex = require('poloniex.js');
+const keys = require('../../api-key')['poloniex'];
+
+Promise.promisifyAll(Poloniex.prototype, {
+	filter: (name, func, target, passesDefaultFilter) => {
+		return passesDefaultFilter || name == '_private';
+	}
+});
+
+module.exports = {
+	getAllTransactions: () => {
+		const dateLimit = new Date(2017,3,1,0,0,0,0);
+		const poloniex = new Poloniex(keys.api_key, keys.api_secret);
+
+		const parameters = {
+			currencyPair: 'all',
+			start: Math.floor(dateLimit.getTime() / 1000),
+			end: Math.floor(new Date().getTime() / 1000)
+		};
+
+		return Promise.all([
+				poloniex._privateAsync('returnDepositsWithdrawals', parameters),
+				poloniex._privateAsync('returnTradeHistory', parameters)
+			])
+			.then((results) => {
+				const currencies = {};
+				const withdrawals = results[0].withdrawals;
+				const deposits = results[0].deposits;
+				if (!deposits || !withdrawals) {
+					console.error('Invalid response from poloniex');
+					console.log(JSON.stringify(results[0]));
+					throw new Error('Could not retreive withdrawals/deposits');
+				}
+				const trades = results[1];
+
+				// Deposits
+				deposits.forEach((data) => {
+					if (data.status && data.status.indexOf('COMPLETE') === 0) {
+						const currency = data.currency,
+							dt = moment.unix(data['timestamp']),
+							amount = parseNum(data['amount']);
+						const trx = {
+							exchange: 'poloniex',
+							type: 'deposit',
+							currency: currency,
+							date: dt.toDate(),
+							ts: +dt,
+							amount: amount,
+							change: amount,
+							fill: data
+						};
+
+						if (!currencies[currency]) {
+							currencies[currency] = {
+								exchange: 'poloniex',
+								currency: currency,
+								trx: []
+							};
+						}
+						currencies[currency].trx.push(trx);
+					}
+				});
+
+				// Withdrawals
+				withdrawals.forEach((data) => {
+					if (data.status && data.status.indexOf('COMPLETE') === 0) {
+						const currency = data.currency,
+							dt = moment.unix(data['timestamp']),
+							amount = parseNum(data['amount']),
+							fee = parseNum(data['fee']);
+						const trx = {
+							exchange: 'poloniex',
+							type: 'withdrawal',
+							currency: currency,
+							date: dt.toDate(),
+							ts: +dt,
+							amount: amount,
+							change: 0 - amount,
+							fee: fee,
+							fee_currency: currency,
+							real_amount: amount - fee,
+							fill: data
+						};
+
+						if (!currencies[currency]) {
+							currencies[currency] = {
+								exchange: 'poloniex',
+								currency: currency,
+								trx: []
+							};
+						}
+						currencies[currency].trx.push(trx);
+					}
+				});
+
+				// Trades
+				Object.keys(trades).forEach((mkt) => {
+					const mktParts = mkt.split('_'),
+						currency = mktParts[1],
+						priceCurrency = mktParts[0];
+
+					trades[mkt].forEach((data) => {
+						const dt = moment(data['date']),
+							type = data['type'],
+							amount = parseNum(data['amount']),
+							price = parseNum(data['rate']),
+							feeRate = parseNum(data['fee']),
+							total = parseNum(data['total']);
+						if (type !== 'buy' && type !== 'sell') {
+							console.error(`!!!!!!! UKNOWN TRADE TYPE ${type} !!!!!!!!!!!!`);
+						}
+						const trx = {
+							exchange: 'poloniex',
+							type: type,
+							currency: currency,
+							date: dt.toDate(),
+							ts: +dt,
+							amount: amount,
+							change: amount,
+							price: price,
+							price_currency: priceCurrency,
+							cost: total,
+							fee: 0,
+							fee_rate: feeRate,
+							fee_currency: '',
+							fill: data
+						};
+						if (trx.type === 'buy') {
+							trx.fee_currency = currency;
+							trx.fee = trx.fee_rate * amount;
+							trx.change = amount - trx.fee;
+						} else if (trx.type === 'sell') {
+							trx.fee_currency = priceCurrency;
+							trx.fee = trx.fee_rate * total;
+							trx.change = 0 - amount;
+							trx.cost = total - trx.fee;
+						}
+
+						if (!currencies[currency]) {
+							currencies[currency] = {
+								exchange: 'poloniex',
+								currency: currency,
+								trx: []
+							};
+						}
+						currencies[currency].trx.push(trx);
+					});
+				});
+
+				Object.keys(currencies).forEach(currency => {
+					const data = currencies[currency];
+					data.trx.sort((x, y) => {
+						return (+x.date) - (+y.date);
+					});
+				});
+
+				return currencies;
+			});
+	}
+}
+
+/* Trades
+{
+  "globalTradeID": 176404792,
+  "tradeID": "10359833",
+  "date": "2017-06-25 06:41:34",
+  "rate": "0.00010760",
+  "amount": "3437.09256845",
+  "total": "0.36983116",
+  "fee": "0.00250000",
+  "orderNumber": "60699229128",
+  "type": "sell",
+  "category": "exchange"
+},
+{
+  "globalTradeID": 176375201,
+  "tradeID": "10358712",
+  "date": "2017-06-25 05:22:10",
+  "rate": "0.00010738",
+  "amount": "3445.70683553",
+  "total": "0.36999999",
+  "fee": "0.00250000",
+  "orderNumber": "60692561802",
+  "type": "buy",
+  "category": "exchange"
+},
+*/
+
+/* Widthdrawls
+{ withdrawalNumber: 4297927,
+   currency: 'BTC',
+   address: '1HQuKJDgcR9B6Nd6LWj9ASGyfey3PMpnUZ',
+   amount: '0.12263813',
+   fee: '0.00010000',
+   timestamp: 1496112390,
+   status: 'COMPLETE: 558f2b697869e2402eb5e8ecfc13d3a650ceda1226455f86d728422d3ac6f92b',
+   ipAddress: '108.48.90.118'
+}*/
+
+/* Deposits
+{ currency: 'BTC',
+   address: '1EZ5QbP4nKFDoU8jRw2rVmNW1CAy54F1ZF',
+   amount: '0.12183813',
+   confirmations: 1,
+   txid: '1eff351ee41832d6cb84abbeb8bb30b18f383a1ba847b849f32cdd4bdc8096f9',
+   timestamp: 1496042100,
+   status: 'COMPLETE'
+ }
+ */

--- a/lib/follow-money.js
+++ b/lib/follow-money.js
@@ -3,6 +3,44 @@ const _ = require('lodash');
 const moment = require('moment');
 const cryptodb = require('./mongo-db');
 
+const wallets = require('./wallets');
+
+const exceptions = {
+	currency: {
+		'SEC': 'SAFEX',
+		'SAFEX': 'SEC',
+		'DASH': 'DSH',
+		'DSH': 'DASH'
+	},
+	time: {
+		'BTC': {
+			maxHours: 4
+		},
+		'XMR': {
+			maxHours: 6
+		}
+	},
+	diff: {
+		'XRP': 0.31,
+		'ETH': 0.003,
+		'ETC': 0.02,
+		'BTC': 0.02,
+		'XVG': 2,
+		'NXT': 1,
+		'SAFEX': 2,
+		'SEC': 2,
+		'DOGE': 6,
+		'LSK': 0.1,
+		'XMR': 0.03,
+		'DASH': 0.01,
+		'DSH': 0.01,
+		'LTC': 0.002
+	}
+};
+
+const SPECIAL_IDS = [];
+//const SPECIAL_IDS = ['5957422fbf8aac8937a37c4c', '5956a83abceb505c710fe60f'];
+
 const findPair = (trx, list) => {
 	if (!list.length) {
 		return -1;
@@ -10,15 +48,19 @@ const findPair = (trx, list) => {
 	const dt = moment(trx.date);
 	return list.findIndex(next => {
 		// Must be same currency
-		if (next.currency !== trx.currency) {
+		if (next.currency !== trx.currency && (!exceptions.currency[next.currency] || exceptions.currency[next.currency] !== trx.currency)) {
 			return false;
 		}
 		// Can't be on the same exchange
 		if (next.exchange === trx.exchange) {
 			return false;
 		}
-		// If they're more than an hour apart they're not a pair
-		if (Math.abs(dt.diff(next.date, 'hours')) > 1) {
+		// If they're more than 4 hours apart they're not a pair
+		const hourDiff = Math.abs(dt.diff(next.date, 'hours'));
+		if (SPECIAL_IDS.indexOf('' + trx._id) !== -1 && SPECIAL_IDS.indexOf('' + next._id) !== -1) {
+			console.log(`^^^^^^ hourDiff: ${hourDiff}`);
+		}
+		if (hourDiff > 1 && (!exceptions.time[next.currency] || hourDiff > exceptions.time[next.currency].maxHours)) {
 			return false;
 		}
 		// If the amounts are identical, we're good
@@ -29,15 +71,68 @@ const findPair = (trx, list) => {
 		const wd = trx.type === 'withdrawal' ? trx : next;
 		let realAmount = wd.real_amount ? wd.real_amount : wd.amount;
 		const diff = Math.abs(dep.amount - realAmount);
-		if (diff === 0 || diff < 0.001) {
-			if (diff !== 0 && diff > 0.0000001) {
+		if (SPECIAL_IDS.indexOf('' + trx._id) !== -1 && SPECIAL_IDS.indexOf('' + next._id) !== -1) {
+			console.log(`^^^^^^ amountDiff: ${diff}`);
+		}
+		if (diff === 0 || diff < 0.001 || (exceptions.diff[next.currency] && diff <= exceptions.diff[next.currency])) {
+			/*if (diff !== 0 && diff > 0.0000001) {
 				console.log(`Ignoring difference of ${diff} with time diff of ${Math.abs(dt.diff(next.date, 'seconds'))}`);
-			}
+			}*/
 			return true;
 		}
 		return false;
 	});
-}
+};
+
+const findWallet = (trx) => {
+	let addr = _.get(trx, 'fill.address') || _.get(trx, 'move.address') || _.get(trx, 'fill.Address') || _.get(trx, 'withdrawal_target.address');
+	if (!addr) {
+		return false;
+	}
+	if (trx.exchange === 'bittrex' && addr.indexOf(':') !== -1) {
+		addr = addr.split(':')[0];
+	}
+
+	if (wallets[addr]) {
+		let wallet = wallets[addr];
+		if (wallet.subId) {
+			wallet = wallet[wallet.defaultId];
+		}
+		return wallet;
+	}
+	return false;
+};
+
+const getWithdrawalCategory = (trx) => {
+	const wdTarget = _.get(trx, 'withdrawal_target.name');
+	if (wdTarget && wdTarget.indexOf('Bank') === 0) {
+		return 'bank';
+	}
+	const targetId = _.get(trx, 'withdrawal_target.id');
+	// Steve & Ayo
+	if (targetId && (targetId === '07c7aa7d-552b-5ac7-83ae-57892f36eabb' || targetId === 'fe6b4482-13f5-531f-bcb9-f549154c7adf')) {
+		return 'known';
+	}
+	return 'other';
+};
+
+const getDepositCategory = (trx) => {
+	const depSrc = _.get(trx, 'deposit_source.name');
+	if (depSrc) {
+		if (depSrc.indexOf('Bank') === 0) {
+			return 'bank'
+		}
+		if (depSrc === 'gdax') {
+			return 'gdaxIssues';
+		}
+	}
+	const targetId = _.get(trx, 'deposit_source.id');
+	// Idris
+	if (targetId && targetId === 'afbcb8ce-930c-57bc-b3e9-3c2d8ad6d3a5') {
+		return 'known';
+	}
+	return 'other';
+};
 
 return cryptodb.connect()
 .then(db => {
@@ -47,8 +142,9 @@ return cryptodb.connect()
 	const collbittrex = db.collection('bittrex');
 	const collpoloniex = db.collection('poloniex');
 	const collcryptopia = db.collection('cryptopia');
+	const collbitstamp = db.collection('bitstamp');
 
-	return Promise.reduce([collgdax, collcoinbase, collbitfinex, collbittrex, collpoloniex, collcryptopia], (allTrx, coll) => {
+	return Promise.reduce([collgdax, collcoinbase, collbitfinex, collbittrex, collpoloniex, collcryptopia, collbitstamp], (allTrx, coll) => {
 		return coll.findAsync({
 			type: { "$in": ['deposit', 'withdrawal'] }
 		})
@@ -65,33 +161,103 @@ return cryptodb.connect()
 	transfers.sort((x, y) => {
 		return (+x.date) - (+y.date);
 	});
-	const wds = [],
-		dps = [],
-		pairs = [];
+	const wds = { other: [], known: [], bank: [] },
+		dps = { other: [], known: [], bank: [] },
+		pairs = [],
+		otherTrans = [],
+		externalTrans = [],
+		canceled = [],
+		usdDepositPairs = [];
 	transfers.forEach(trx => {
+		if (_.get(trx, 'move.description') && _.get(trx, 'move.description').indexOf('canceled by User') !== -1) {
+			canceled.push(trx);
+			return;
+		}
+		if (_.get(trx, 'fill.Canceled')) {
+			canceled.push(trx);
+			return;
+		}
 		if (trx.type === 'withdrawal') {
-			const idx = findPair(trx, dps);
+			const idx = findPair(trx, dps['other']);
 			if (idx === -1) {
-				wds.push(trx);
+				let wall = findWallet(trx);
+				if (wall) {
+					if (wall.owner === 'Anon') {
+						otherTrans.push(trx);
+					} else if (wall.owner === 'Nate') {
+						externalTrans.push(trx);
+					} else {
+						wds['known'].push(trx);
+					}
+				} else {
+					const cat = getWithdrawalCategory(trx);
+					if (!wds[cat]) {
+						wds[cat] = [];
+					}
+					wds[cat].push(trx);
+				}
 			} else {
-				pairs.push([trx, dps.splice(idx, 1)[0]]);
+				const matchDep = dps['other'].splice(idx, 1)[0];
+				pairs.push([trx, matchDep]);
+				if (matchDep.currency === 'USD') {
+					usdDepositPairs.push([trx, matchDep]);
+				}
 			}
 		} else {
-			const idx = findPair(trx, wds);
+			const idx = findPair(trx, wds['other']);
 			if (idx === -1) {
-				dps.push(trx);
+				let wall = findWallet(trx);
+				if (wall) {
+					if (wall.owner === 'Anon') {
+						otherTrans.push(trx);
+					} else if (wall.owner === 'Nate') {
+						externalTrans.push(trx);
+					} else {
+						dps['known'].push(trx);
+					}
+				} else {
+					const cat = getDepositCategory(trx);
+					if (!dps[cat]) {
+						dps[cat] = [];
+					}
+					dps[cat].push(trx);
+				}
 			} else {
-				pairs.push([trx, wds.splice(idx, 1)[0]]);
+				const matchWd = wds['other'].splice(idx, 1)[0];
+				pairs.push([trx, matchWd]);
+				if (trx.currency === 'USD') {
+					usdDepositPairs.push([trx, matchWd]);
+				}
 			}
 		}
 	});
-	console.log(JSON.stringify({
-		deposits: dps,
-		withdrawals: wds,
+	const fullList = [].concat(dps['other']).concat(wds['other']);
+	fullList.sort((x, y) => {
+		return (+x.date) - (+y.date);
+	});
+	const bankList = [].concat(dps['bank']).concat(wds['bank']);
+	bankList.sort((x, y) => {
+		return (+x.date) - (+y.date);
+	});
+	const summary = {
 		pairCount: pairs.length,
-		dpCount: dps.length,
-		wdCount: wds.length
-	}));
+		otherCount: otherTrans.length,
+		canceled: canceled.length
+	};
+	Object.keys(dps).forEach(dpName => {
+		summary[`dps.${dpName}`] = dps[dpName].length;
+	});
+	Object.keys(wds).forEach(wdName => {
+		summary[`wds.${wdName}`] = wds[wdName].length;
+	});
+	summary['list'] = fullList;
+	/*summary['list'] = fullList.map(next => {
+		return _.pick(next, ['exchange', 'type', 'currency', 'amount', 'change', 'date', 'fill']);
+	});*/
+	//console.log(JSON.stringify(bankList));
+	//console.log(JSON.stringify(pairs));
+	console.log(JSON.stringify(summary));
+	//console.log(JSON.stringify(usdDepositPairs));
 })
 .then(() => {
 	process.exit();

--- a/lib/follow-money.js
+++ b/lib/follow-money.js
@@ -1,0 +1,102 @@
+const Promise = require('bluebird');
+const _ = require('lodash');
+const moment = require('moment');
+const cryptodb = require('./mongo-db');
+
+const findPair = (trx, list) => {
+	if (!list.length) {
+		return -1;
+	}
+	const dt = moment(trx.date);
+	return list.findIndex(next => {
+		// Must be same currency
+		if (next.currency !== trx.currency) {
+			return false;
+		}
+		// Can't be on the same exchange
+		if (next.exchange === trx.exchange) {
+			return false;
+		}
+		// If they're more than an hour apart they're not a pair
+		if (Math.abs(dt.diff(next.date, 'hours')) > 1) {
+			return false;
+		}
+		// If the amounts are identical, we're good
+		if (next.amount === trx.amount) {
+			return true;
+		}
+		const dep = trx.type === 'deposit' ? trx : next;
+		const wd = trx.type === 'withdrawal' ? trx : next;
+		let realAmount = wd.real_amount ? wd.real_amount : wd.amount;
+		const diff = Math.abs(dep.amount - realAmount);
+		if (diff === 0 || diff < 0.001) {
+			if (diff !== 0 && diff > 0.0000001) {
+				console.log(`Ignoring difference of ${diff} with time diff of ${Math.abs(dt.diff(next.date, 'seconds'))}`);
+			}
+			return true;
+		}
+		return false;
+	});
+}
+
+return cryptodb.connect()
+.then(db => {
+	const collgdax = db.collection('gdax');
+	const collcoinbase = db.collection('coinbase');
+	const collbitfinex = db.collection('bitfinex');
+	const collbittrex = db.collection('bittrex');
+	const collpoloniex = db.collection('poloniex');
+	const collcryptopia = db.collection('cryptopia');
+
+	return Promise.reduce([collgdax, collcoinbase, collbitfinex, collbittrex, collpoloniex, collcryptopia], (allTrx, coll) => {
+		return coll.findAsync({
+			type: { "$in": ['deposit', 'withdrawal'] }
+		})
+			.then(cursor => {
+				return cursor.toArrayAsync();
+			})
+			.then(arr => {
+				return allTrx.concat(arr);
+			});
+	}, [])
+})
+.then(transfers => {
+	//console.log(`${transfers.length} transfers found`);
+	transfers.sort((x, y) => {
+		return (+x.date) - (+y.date);
+	});
+	const wds = [],
+		dps = [],
+		pairs = [];
+	transfers.forEach(trx => {
+		if (trx.type === 'withdrawal') {
+			const idx = findPair(trx, dps);
+			if (idx === -1) {
+				wds.push(trx);
+			} else {
+				pairs.push([trx, dps.splice(idx, 1)[0]]);
+			}
+		} else {
+			const idx = findPair(trx, wds);
+			if (idx === -1) {
+				dps.push(trx);
+			} else {
+				pairs.push([trx, wds.splice(idx, 1)[0]]);
+			}
+		}
+	});
+	console.log(JSON.stringify({
+		deposits: dps,
+		withdrawals: wds,
+		pairCount: pairs.length,
+		dpCount: dps.length,
+		wdCount: wds.length
+	}));
+})
+.then(() => {
+	process.exit();
+})
+.catch(err => {
+	console.error(err);
+	process.exit();
+});

--- a/lib/get-portfolio.js
+++ b/lib/get-portfolio.js
@@ -14,7 +14,14 @@ const getCurrencyName = (trx) => {
 	if (currencyNames[curr]) {
 		curr = currencyNames[curr];
 	}
-	return curr;
+	let priceCurr = trx.price_currency || 'ZZZZ';
+	if (currencyNames[priceCurr]) {
+		priceCurr = currencyNames[priceCurr];
+	}
+	return {
+		currency: curr,
+		priceCurrency: priceCurr
+	};
 };
 
 return cryptodb.connect()
@@ -40,8 +47,9 @@ return cryptodb.connect()
 	}, [])
 })
 .then(allTrx => {
-	const portfolio = allTrx.reduce((balances, trx) => {
-		const currency = getCurrencyName(trx);
+	const { balances, spending } = allTrx.reduce((tracker, trx) => {
+		const balances = tracker.balances;
+		const {currency, priceCurrency } = getCurrencyName(trx);
 		if (!balances[currency]) {
 			balances[currency] = {
 				currency: currency,
@@ -61,19 +69,51 @@ return cryptodb.connect()
 			balances[currency].trx[trx.type] = 0;
 		}
 		balances[currency].trx[trx.type] += 1;
+		tracker.balances = balances;
 
-		return balances;
+		if (trx.type === 'buy' || trx.type === 'sell') {
+			const spending = tracker.spending;
+			if (!spending[priceCurrency]) {
+				spending[priceCurrency] = {
+					currency: priceCurrency,
+					balance: 0,
+					exchanges: [],
+					trx: {
+						total: 0
+					}
+				};
+			}
+			if (trx.exchange === 'cryptopia' || trx.exchange === 'poloniex' || trx.exchange === 'coinbase') {
+				if (trx.type === 'buy' || trx.exchange === 'coinbase') {
+					spending[priceCurrency].balance -= trx.cost;
+				} else {
+					spending[priceCurrency].balance += trx.cost;
+				}
+				if (spending[priceCurrency].exchanges.indexOf(trx.exchange) === -1) {
+					spending[priceCurrency].exchanges.push(trx.exchange);
+				}
+				spending[priceCurrency].trx.total += 1;
+				if (!spending[priceCurrency].trx[trx.type]) {
+					spending[priceCurrency].trx[trx.type] = 0;
+				}
+				spending[priceCurrency].trx[trx.type] += 1;
+			}
+			tracker.spending = spending;
+		}
+
+		return tracker;
 	}, {});
 	const trimmed = {
 		numWrong: 0,
 		numValid: 0,
 		numEmpty: 0,
+		spending: spending,
 		wrong: [],
 		valid: [],
 		empty: []
 	};
-	Object.keys(portfolio).forEach(currency => {
-		const info = portfolio[currency];
+	Object.keys(balances).forEach(currency => {
+		const info = balances[currency];
 		if (info.balance <= -1) {
 			trimmed.wrong.push(info);
 		} else if (info.balance > 0.001) {

--- a/lib/get-portfolio.js
+++ b/lib/get-portfolio.js
@@ -1,0 +1,94 @@
+const Promise = require('bluebird');
+const _ = require('lodash');
+const moment = require('moment');
+const cryptodb = require('./mongo-db');
+
+const currencyNames = {
+	'SAFEX': 'SEC',
+	'DSH': 'DASH',
+	'XMY': 'MYR'
+};
+
+const getCurrencyName = (trx) => {
+	let curr = trx.currency || 'ZZZZ';
+	if (currencyNames[curr]) {
+		curr = currencyNames[curr];
+	}
+	return curr;
+};
+
+return cryptodb.connect()
+.then(db => {
+	const collgdax = db.collection('gdax');
+	const collcoinbase = db.collection('coinbase');
+	const collbitfinex = db.collection('bitfinex');
+	const collbittrex = db.collection('bittrex');
+	const collpoloniex = db.collection('poloniex');
+	const collcryptopia = db.collection('cryptopia');
+	const collbitstamp = db.collection('bitstamp');
+
+	return Promise.reduce([collgdax, collcoinbase, collbitfinex, collbittrex, collpoloniex, collcryptopia, collbitstamp], (allTrx, coll) => {
+		return coll.findAsync({
+			type: { "$exists": true }
+		})
+			.then(cursor => {
+				return cursor.toArrayAsync();
+			})
+			.then(arr => {
+				return allTrx.concat(arr);
+			});
+	}, [])
+})
+.then(allTrx => {
+	const portfolio = allTrx.reduce((balances, trx) => {
+		const currency = getCurrencyName(trx);
+		if (!balances[currency]) {
+			balances[currency] = {
+				currency: currency,
+				balance: 0,
+				exchanges: [],
+				trx: {
+					total: 0
+				}
+			};
+		}
+		balances[currency].balance += trx.change;
+		if (balances[currency].exchanges.indexOf(trx.exchange) === -1) {
+			balances[currency].exchanges.push(trx.exchange);
+		}
+		balances[currency].trx.total += 1;
+		if (!balances[currency].trx[trx.type]) {
+			balances[currency].trx[trx.type] = 0;
+		}
+		balances[currency].trx[trx.type] += 1;
+
+		return balances;
+	}, {});
+	const trimmed = {
+		numWrong: 0,
+		numValid: 0,
+		numEmpty: 0,
+		wrong: [],
+		valid: [],
+		empty: []
+	};
+	Object.keys(portfolio).forEach(currency => {
+		const info = portfolio[currency];
+		if (info.balance <= -1) {
+			trimmed.wrong.push(info);
+		} else if (info.balance > 0.001) {
+			trimmed.valid.push(info);
+		} else {
+			trimmed.empty.push(currency);
+		}
+	});
+	trimmed.numWrong = trimmed.wrong.length;
+	trimmed.numValid = trimmed.valid.length;
+	trimmed.numEmpty = trimmed.empty.length;
+	console.log(JSON.stringify(trimmed));
+	process.exit();
+})
+.catch(err => {
+	console.error(err);
+	process.exit();
+});

--- a/lib/mongo-db.js
+++ b/lib/mongo-db.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const Promise = require('bluebird');
+const mongodb = require('mongodb');
+
+const cryptosDbHost = process.env.CRYPTOS_DB_HOST || 'localhost';
+const cryptosDbPort = process.env.CRYPTOS_DB_PORT || '27017';
+const cryptosDbUrl = `${cryptosDbHost}:${cryptosDbPort}/cryptos`;
+
+const MongoClient = Promise.promisifyAll(mongodb).MongoClient;
+const Collection = mongodb.Collection;
+Promise.promisifyAll(Collection.prototype);
+Promise.promisifyAll(MongoClient);
+
+module.exports = {
+	connect: function () {
+		return MongoClient.connectAsync(`mongodb://${cryptosDbUrl}`);
+	},
+	CRYPTOS_URL: cryptosDbUrl
+};

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "poloniex.js": "0.0.7",
     "prom-client": "^9.0.0",
     "request": "^2.81.0",
+    "request-promise": "^4.2.1",
     "rest": "^2.0.0",
     "simple-statistics": "^1.0.1",
     "stats-lite": "^2.0.4"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "async": "^2.4.1",
     "bluebird": "^3.2.2",
+    "coinbase": "^2.0.6",
     "cryptocompare": "^0.1.0",
     "elasticsearch": "^13.0.1",
     "express": "^4.15.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "cryptocompare": "^0.1.0",
     "elasticsearch": "^13.0.1",
     "express": "^4.15.3",
+    "gdax": "^0.4.2",
     "lodash": "^4.17.4",
     "mathjs": "^3.13.2",
     "moment": "^2.11.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@you21979/bittrex.com": "0.0.4",
     "async": "^2.4.1",
     "bitfinex-api-node": "^1.0.1",
+    "bitstamp-promise": "^1.0.1",
     "bluebird": "^3.2.2",
     "coinbase": "^2.0.6",
     "cryptocompare": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "async": "^2.4.1",
+    "bitfinex-api-node": "^1.0.1",
     "bluebird": "^3.2.2",
     "coinbase": "^2.0.6",
     "cryptocompare": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     ]
   },
   "dependencies": {
+    "@you21979/bittrex.com": "0.0.4",
     "async": "^2.4.1",
     "bitfinex-api-node": "^1.0.1",
     "bluebird": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "bluebird": "^3.2.2",
     "coinbase": "^2.0.6",
     "cryptocompare": "^0.1.0",
+    "csv-parser": "^1.11.0",
     "elasticsearch": "^13.0.1",
     "express": "^4.15.3",
     "gdax": "^0.4.2",


### PR DESCRIPTION
Add per-exchange libraries for pulling down & aggregating all deposit, withdrawals, trades, etc. for:
* poloniex
* bittrex (this requires manually downloading a separate csv file as well)
* coinbase
* gdax
* cryptopia
* bitfinex
* bitstamp

Current scripts will pull from these API's and write to a local mongo instance using a separate collection for each exchange.  This allows for writing scripts to parse the transaction data without having the hit the API's every time (especially since some APIs have easy-to-exceed querying thresholds).