### PR TITLE
Scan Bittrex for coin changes

### DIFF
--- a/lib/exchanges/bittrex.js
+++ b/lib/exchanges/bittrex.js
@@ -1,12 +1,15 @@
 const Promise = require('bluebird');
 const moment = require('moment');
 const _ = require('lodash');
+const fs = Promise.promisifyAll(require('fs'));
 const parseNum = require('parse-decimal-number');
 
 const bittrexAPI = require('@you21979/bittrex.com');
 const keys = require('../../api-key')['bittrex'];
 const bittrex = bittrexAPI.createPrivateApi(keys.api_key, keys.api_secret, 'I am Bot');
 const bittrexPub = bittrexAPI.PublicApi;
+
+const history = require('../../local/bittrex-history');
 
 module.exports = {
 	/* Sample output
@@ -349,8 +352,196 @@ module.exports = {
 						return orders;
 					});
 			});
+	},
+
+	getMarketHistory: (coin, count, currency) => {
+		currency = (currency || 'BTC').toUpperCase();
+		let market = `${currency}-${coin.toUpperCase()}`;
+		return bittrexPub.getMarketHistory(market, count);
+	},
+
+	getMarketSummaries: () => {
+		return bittrexPub.getMarketSummaries();
+	},
+
+	findMarketMovement: () => {
+		return Promise.all([
+			module.exports.getMarketSummaries(),
+			module.exports.updateHistory(history)
+		])
+			.then(res => {
+				const tickers = res[0];
+				const updated = res[1];
+				let numUpdates = 0;
+				tickers.forEach(ticker => {
+					if (ticker["MarketName"].indexOf('BTC') === 0) {
+						const coin = ticker["MarketName"].split('-')[1];
+						if (updated[coin] && updated[coin].trades.length) {
+							const lastTrade = updated[coin].trades[0];
+							const dtTicker = moment(ticker["TimeStamp"] + 'Z');
+							const dtLast = moment(lastTrade.ts);
+							const diff = dtTicker.diff(moment(lastTrade.ts), 'minutes');
+							if (diff >= 2) {
+								//console.log(`${diff} minutes since last trade for ${coin}, adding to history`);
+								updated[coin].trades.unshift({
+									ts: +dtTicker,
+									price: ticker["Last"]
+								});
+								numUpdates++;
+							}
+						}
+					}
+				});
+				console.log(`Updated ${numUpdates} coins`);
+				findBigChanges(updated);
+				const toSave = cleanupTradeHistory(updated);
+				return module.exports.saveHistory(toSave)
+					.then(() => {
+						return updated;
+					});
+			});
+	},
+
+	updateHistory: (currHistory) => {
+		return module.exports.getMarkets()
+			.then((markets) => {
+				const toAdd = [];
+				markets.forEach(mkt => {
+					if (mkt['BaseCurrency'] === 'BTC' && !currHistory[mkt['MarketCurrency']]) {
+						toAdd.push(mkt['MarketCurrency']);
+					}
+				});
+				if (toAdd.length) {
+					const promises = [];
+					for (let i = 0; i < 40 && i < (toAdd.length - 1); i++) {
+						const currCoin = toAdd[i];
+						console.log(`Fetching history for ${currCoin}`);
+						promises.push(module.exports.getMarketHistory(currCoin, 300)
+							.then(trades => {
+								return {
+									coin: currCoin,
+									trades: trades
+								};
+							}));
+					}
+					return Promise.all(promises)
+						.then(queries => {
+							queries.forEach(tradeInfo => {
+								const trades = reduceTradeHistory(tradeInfo.trades);
+								currHistory[tradeInfo.coin] = {
+									coin: tradeInfo.coin,
+									trades: trades
+								};
+							});
+							return currHistory;
+						});
+				}
+				return currHistory;
+			});
+	},
+
+	saveHistory: (toSave) => {
+		const fileStr = `module.exports = ${JSON.stringify(toSave, null, 2)};`;
+		return fs.writeFileAsync('./local/bittrex-history.js', fileStr, 'utf8');
 	}
 };
+
+const reduceTradeHistory = (rawTradeData) => {
+	const trades = rawTradeData.map(data => {
+		const dt = moment(data.TimeStamp + 'Z');
+		return {
+			ts: +dt,
+			price: data.Price
+		};
+	});
+	trades.sort((a, b) => {
+		return b.ts - a.ts;
+	});
+
+	const origCount = trades.length;
+	let lastTrade = trades[0];
+	let dtLast = moment(lastTrade.ts);
+	const reduced = [lastTrade];
+
+	trades.forEach(trade => {
+		let dt = moment(trade.ts);
+		if (dtLast.diff(dt, 'minutes') >= 2) {
+			lastTrade = trade;
+			dtLast = dt;
+			reduced.push(lastTrade);
+		}
+	});
+
+	return reduced;
+};
+
+const cleanupTradeHistory = (market) => {
+	const clean = {};
+	Object.keys(market).forEach(key => {
+		const data = market[key];
+		if (data.trades.length) {
+			const dtLast = moment(data.trades[0].ts);
+			const newTrades = data.trades.filter(trade => {
+				return dtLast.diff(moment(trade.ts), 'minutes') <= 120;
+			});
+			clean[key] = {
+				coin: data.coin,
+				trades: newTrades
+			};
+		}
+	});
+	return clean;
+};
+
+const findBigChanges = (market) => {
+	const swings = [];
+
+	Object.keys(market).forEach(coin => {
+		let trades = market[coin].trades;
+		if (trades.length) {
+			let lastPrice = trades[0].price;
+			let dtLast = moment(trades[0].ts);
+			trades.some(trade => {
+				let dtTrade = moment(trade.ts);
+				let mins = dtLast.diff(dtTrade, 'minutes');
+				if (mins > 0 && mins < 60) {
+					let chg = lastPrice - trade.price;
+					let pctChg = _.floor(((chg / trade.price) * 100), 2);
+					let absChg = Math.abs(pctChg);
+					if (absChg >= 6 || (absChg >= 4 && mins < 30) || (absChg >= 2 && mins <= 15)) {
+						swings.push({
+							coin: coin,
+							change: pctChg,
+							minutes: mins
+						});
+						return true;
+					}
+				}
+				return false;
+			});
+		}
+	});
+
+	swings.sort((a,b) => {
+		return b.change - a.change;
+	});
+
+	swings.forEach(next => {
+		console.log(`${next.change}% in ${next.minutes} mins (${next.coin})`);
+	});
+
+	return swings;
+};
+
+/*
+return module.exports.findMarketMovement()
+	.then((updated) => {
+		Object.keys(updated).forEach(coin => {
+			const data = updated[coin];
+		});
+		process.exit();
+	});
+*/
 
 /* Sample Orders
 {

--- a/lib/exchanges/bittrex.js
+++ b/lib/exchanges/bittrex.js
@@ -1,15 +1,11 @@
 const Promise = require('bluebird');
 const moment = require('moment');
-const _ = require('lodash');
-const fs = Promise.promisifyAll(require('fs'));
 const parseNum = require('parse-decimal-number');
 
 const bittrexAPI = require('@you21979/bittrex.com');
 const keys = require('../../api-key')['bittrex'];
 const bittrex = bittrexAPI.createPrivateApi(keys.api_key, keys.api_secret, 'I am Bot');
 const bittrexPub = bittrexAPI.PublicApi;
-
-const history = require('../../local/bittrex-history');
 
 module.exports = {
 	/* Sample output
@@ -247,10 +243,6 @@ module.exports = {
 		});
 	},
 
-	getMarkets: () => {
-		return bittrexPub.getMarkets()
-	},
-
 	getOldOrderHistory: () => {
 		/*
 		const CSVReader = require('promised-csv');
@@ -354,194 +346,20 @@ module.exports = {
 			});
 	},
 
-	getMarketHistory: (coin, count, currency) => {
+	getMarkets: () => {
+		return bittrexPub.getMarkets();
+	},
+
+	getMarketHistory: (coin, maxCount, currency) => {
 		currency = (currency || 'BTC').toUpperCase();
 		let market = `${currency}-${coin.toUpperCase()}`;
-		return bittrexPub.getMarketHistory(market, count);
+		return bittrexPub.getMarketHistory(market, maxCount);
 	},
 
 	getMarketSummaries: () => {
 		return bittrexPub.getMarketSummaries();
-	},
-
-	findMarketMovement: () => {
-		return Promise.all([
-			module.exports.getMarketSummaries(),
-			module.exports.updateHistory(history)
-		])
-			.then(res => {
-				const tickers = res[0];
-				const updated = res[1];
-				let numUpdates = 0;
-				tickers.forEach(ticker => {
-					if (ticker["MarketName"].indexOf('BTC') === 0) {
-						const coin = ticker["MarketName"].split('-')[1];
-						if (updated[coin] && updated[coin].trades.length) {
-							const lastTrade = updated[coin].trades[0];
-							const dtTicker = moment(ticker["TimeStamp"] + 'Z');
-							const dtLast = moment(lastTrade.ts);
-							const diff = dtTicker.diff(moment(lastTrade.ts), 'minutes');
-							if (diff >= 2) {
-								//console.log(`${diff} minutes since last trade for ${coin}, adding to history`);
-								updated[coin].trades.unshift({
-									ts: +dtTicker,
-									price: ticker["Last"]
-								});
-								numUpdates++;
-							}
-						}
-					}
-				});
-				console.log(`Updated ${numUpdates} coins`);
-				findBigChanges(updated);
-				const toSave = cleanupTradeHistory(updated);
-				return module.exports.saveHistory(toSave)
-					.then(() => {
-						return updated;
-					});
-			});
-	},
-
-	updateHistory: (currHistory) => {
-		return module.exports.getMarkets()
-			.then((markets) => {
-				const toAdd = [];
-				markets.forEach(mkt => {
-					if (mkt['BaseCurrency'] === 'BTC' && !currHistory[mkt['MarketCurrency']]) {
-						toAdd.push(mkt['MarketCurrency']);
-					}
-				});
-				if (toAdd.length) {
-					const promises = [];
-					for (let i = 0; i < 40 && i < (toAdd.length - 1); i++) {
-						const currCoin = toAdd[i];
-						console.log(`Fetching history for ${currCoin}`);
-						promises.push(module.exports.getMarketHistory(currCoin, 300)
-							.then(trades => {
-								return {
-									coin: currCoin,
-									trades: trades
-								};
-							}));
-					}
-					return Promise.all(promises)
-						.then(queries => {
-							queries.forEach(tradeInfo => {
-								const trades = reduceTradeHistory(tradeInfo.trades);
-								currHistory[tradeInfo.coin] = {
-									coin: tradeInfo.coin,
-									trades: trades
-								};
-							});
-							return currHistory;
-						});
-				}
-				return currHistory;
-			});
-	},
-
-	saveHistory: (toSave) => {
-		const fileStr = `module.exports = ${JSON.stringify(toSave, null, 2)};`;
-		return fs.writeFileAsync('./local/bittrex-history.js', fileStr, 'utf8');
 	}
 };
-
-const reduceTradeHistory = (rawTradeData) => {
-	const trades = rawTradeData.map(data => {
-		const dt = moment(data.TimeStamp + 'Z');
-		return {
-			ts: +dt,
-			price: data.Price
-		};
-	});
-	trades.sort((a, b) => {
-		return b.ts - a.ts;
-	});
-
-	const origCount = trades.length;
-	let lastTrade = trades[0];
-	let dtLast = moment(lastTrade.ts);
-	const reduced = [lastTrade];
-
-	trades.forEach(trade => {
-		let dt = moment(trade.ts);
-		if (dtLast.diff(dt, 'minutes') >= 2) {
-			lastTrade = trade;
-			dtLast = dt;
-			reduced.push(lastTrade);
-		}
-	});
-
-	return reduced;
-};
-
-const cleanupTradeHistory = (market) => {
-	const clean = {};
-	Object.keys(market).forEach(key => {
-		const data = market[key];
-		if (data.trades.length) {
-			const dtLast = moment(data.trades[0].ts);
-			const newTrades = data.trades.filter(trade => {
-				return dtLast.diff(moment(trade.ts), 'minutes') <= 120;
-			});
-			clean[key] = {
-				coin: data.coin,
-				trades: newTrades
-			};
-		}
-	});
-	return clean;
-};
-
-const findBigChanges = (market) => {
-	const swings = [];
-
-	Object.keys(market).forEach(coin => {
-		let trades = market[coin].trades;
-		if (trades.length) {
-			let lastPrice = trades[0].price;
-			let dtLast = moment(trades[0].ts);
-			trades.some(trade => {
-				let dtTrade = moment(trade.ts);
-				let mins = dtLast.diff(dtTrade, 'minutes');
-				if (mins > 0 && mins < 60) {
-					let chg = lastPrice - trade.price;
-					let pctChg = _.floor(((chg / trade.price) * 100), 2);
-					let absChg = Math.abs(pctChg);
-					if (absChg >= 6 || (absChg >= 4 && mins < 30) || (absChg >= 2 && mins <= 15)) {
-						swings.push({
-							coin: coin,
-							change: pctChg,
-							minutes: mins
-						});
-						return true;
-					}
-				}
-				return false;
-			});
-		}
-	});
-
-	swings.sort((a,b) => {
-		return b.change - a.change;
-	});
-
-	swings.forEach(next => {
-		console.log(`${next.change}% in ${next.minutes} mins (${next.coin})`);
-	});
-
-	return swings;
-};
-
-/*
-return module.exports.findMarketMovement()
-	.then((updated) => {
-		Object.keys(updated).forEach(coin => {
-			const data = updated[coin];
-		});
-		process.exit();
-	});
-*/
 
 /* Sample Orders
 {

--- a/lib/pct-change-bittrex.js
+++ b/lib/pct-change-bittrex.js
@@ -1,0 +1,190 @@
+const Promise = require('bluebird');
+const moment = require('moment');
+const _ = require('lodash');
+const fs = Promise.promisifyAll(require('fs'));
+
+const bittrex = require('./exchanges/bittrex');
+
+const MAX_CACHED_TRADE_AGE_MINUTES = 120;
+const CACHE_BETWEEN_TRADE_MINUTES = 2;
+const NEW_COINS_PER_RUN = 40;
+const MAX_TRADE_HISTORY_PER_REQUEST = 200;
+
+const bittrexCache = {
+
+	readFromFile: () => {
+		return require('../local/bittrex-history');
+	},
+
+	saveToFile: (cache) => {
+		const toSave = bittrexCache.cleanupOldData(cache);
+		const fileStr = `module.exports = ${JSON.stringify(toSave, null, 2)};`;
+		return fs.writeFileAsync('./local/bittrex-history.js', fileStr, 'utf8');
+	},
+
+	populateCache: (cache) => {
+		return bittrex.getMarkets()
+			.then((markets) => {
+				const toAdd = [];
+				markets.forEach(mkt => {
+					if (mkt['BaseCurrency'] === 'BTC' && !cache[mkt['MarketCurrency']]) {
+						toAdd.push(mkt['MarketCurrency']);
+					}
+				});
+				if (toAdd.length) {
+					const promises = [];
+					for (let i = 0; i < NEW_COINS_PER_RUN && i < (toAdd.length - 1); i++) {
+						const currCoin = toAdd[i];
+						console.log(`Fetching history for ${currCoin}`);
+						promises.push(bittrex.getMarketHistory(currCoin, MAX_TRADE_HISTORY_PER_REQUEST)
+							.then(trades => {
+								return {
+									coin: currCoin,
+									trades: trades
+								};
+							}));
+					}
+					return Promise.all(promises)
+						.then(queries => {
+							queries.forEach(tradeInfo => {
+								const trades = bittrexCache.convertRawTradeData(tradeInfo.trades);
+								cache[tradeInfo.coin] = {
+									coin: tradeInfo.coin,
+									trades: trades
+								};
+							});
+							return cache;
+						});
+				}
+				return cache;
+			});
+	},
+
+	cleanupOldData: (cache) => {
+		const clean = {};
+		Object.keys(cache).forEach(key => {
+			const data = cache[key];
+			if (data.trades.length) {
+				const dtLast = moment(data.trades[0].ts);
+				const newTrades = data.trades.filter(trade => {
+					return dtLast.diff(moment(trade.ts), 'minutes') <= MAX_CACHED_TRADE_AGE_MINUTES;
+				});
+				clean[key] = {
+					coin: data.coin,
+					trades: newTrades
+				};
+			}
+		});
+		return clean;
+	},
+
+	convertRawTradeData: (rawTradeData) => {
+		const trades = rawTradeData.map(data => {
+			const dt = moment(data.TimeStamp + 'Z');
+			return {
+				ts: +dt,
+				price: data.Price
+			};
+		});
+		trades.sort((a, b) => {
+			return b.ts - a.ts;
+		});
+
+		const origCount = trades.length;
+		let lastTrade = trades[0];
+		let dtLast = moment(lastTrade.ts);
+		const reduced = [lastTrade];
+
+		trades.forEach(trade => {
+			let dt = moment(trade.ts);
+			if (dtLast.diff(dt, 'minutes') >= CACHE_BETWEEN_TRADE_MINUTES) {
+				lastTrade = trade;
+				dtLast = dt;
+				reduced.push(lastTrade);
+			}
+		});
+
+		return reduced;
+	}
+};
+
+const fileCache = bittrexCache.readFromFile();
+
+return Promise.all([
+	bittrex.getMarketSummaries(),
+	bittrexCache.populateCache(fileCache)
+])
+.then(res => {
+	const tickers = res[0];
+	const cached = res[1];
+	let numUpdates = 0;
+	tickers.forEach(ticker => {
+		if (ticker["MarketName"].indexOf('BTC') === 0) {
+			const coin = ticker["MarketName"].split('-')[1];
+			if (cached[coin] && cached[coin].trades.length) {
+				const lastTrade = cached[coin].trades[0];
+				const dtTicker = moment(ticker["TimeStamp"] + 'Z');
+				const dtLast = moment(lastTrade.ts);
+				const diff = dtTicker.diff(moment(lastTrade.ts), 'minutes');
+				if (diff >= CACHE_BETWEEN_TRADE_MINUTES) {
+					//console.log(`${diff} minutes since last trade for ${coin}, adding to history`);
+					cached[coin].trades.unshift({
+						ts: +dtTicker,
+						price: ticker["Last"]
+					});
+					numUpdates++;
+				}
+			}
+		}
+	});
+	console.log(`New trades found for ${numUpdates} coins`);
+
+	// Save before passing along
+	return bittrexCache.saveToFile(cached)
+		.then(() => {
+			return cached;
+		});
+})
+.then(cached => {
+	const swings = [];
+
+	Object.keys(cached).forEach(coin => {
+		let trades = cached[coin].trades;
+		if (trades.length) {
+			let lastPrice = trades[0].price;
+			let dtLast = moment(trades[0].ts);
+			trades.some(trade => {
+				let dtTrade = moment(trade.ts);
+				let mins = dtLast.diff(dtTrade, 'minutes');
+				if (mins > 0 && mins < 120) {
+					let chg = lastPrice - trade.price;
+					let pctChg = _.floor(((chg / trade.price) * 100), 2);
+					let absChg = Math.abs(pctChg);
+					if (absChg >= 5 || (absChg >= 2 && mins <= 5)) {
+						swings.push({
+							coin: coin,
+							change: pctChg,
+							minutes: mins
+						});
+						return true;
+					}
+				}
+				return false;
+			});
+		}
+	});
+
+	swings.sort((a,b) => {
+		return b.change - a.change;
+	});
+
+	swings.forEach(next => {
+		console.log(`${next.change}% in ${next.minutes} mins (${next.coin})`);
+	});
+
+	process.exit();
+})
+.catch(err => {
+	console.error(err);
+	process.exit();
+});


### PR DESCRIPTION
Added `pct-chg-bittrex.js` script which scan Bittrex for coins that have had significant price changes in the past few hours.

NOTE: This script requires storing data locally (via a cache written to a file within the `/local` directory) since Bittrex's API doesn't support querying for price history of a coin further back than just the previous 200 trades.

Because of significant differences between Bittrex's API and pretty much every other exchange, this script works differently.  It grabs the last 200 trades for every coin and stores it in a cached file.  The user then must re-run the script repeatedly, each time it will request the latest prices for all Bittrex coins and then add it into the cache.  It then scans the cache to see if there have been any significant price changes in the past 2-60 minutes.